### PR TITLE
Avoid administrative API for edition check when possible

### DIFF
--- a/sonar/platform.py
+++ b/sonar/platform.py
@@ -113,10 +113,10 @@ class Platform:
         :return: the SonarQube platform edition
         :rtype: str ("community", "developer", "enterprise" or "datacenter")
         """
-        if self.version() < (9, 7, 0):
-            return self.sys_info()["Statistics"]["edition"]
-        else:
+        if "edition" in self.global_nav():
             return self.global_nav()["edition"]
+        else:
+            return self.sys_info()["Statistics"]["edition"]
 
     def server_id(self):
         """


### PR DESCRIPTION
Some tools, like _sonar-measures-export_, might be able to run with a non-administrative user, provided that project keys are specified and the user has access to those projects. However, at the very early stage, the script checks for SonarQube server edition to identify whether branches are supported or not. This check is being done in two different approaches:
- with `navigation/global`, available for all users, or
- with `system/info`, available for administrators only.

Currently the choice of the API is hardcoded based on server version; servers below 9.7.0 will go the administrative path and therefore the scripts will not work for non-administrators. [SONAR-10718](https://sonarsource.atlassian.net/browse/SONAR-10718) suggests however that the necessary information is available in versions as low as 7.2. This pull requests changes the logic to first inspect the non-administrative API for edition check and fall back to administrative API only when the information is not available in non-administrative API. This avoids hardcoding server versions and allows non-administrators to use the scripts on servers <9.7.0.