### PR TITLE
Cast the timeout parameter to int

### DIFF
--- a/cli/options.py
+++ b/cli/options.py
@@ -291,7 +291,7 @@ def set_common_args(desc: str) -> argparse.ArgumentParser:
         f"--{HTTP_TIMEOUT}",
         required=False,
         default=10,
-        help="HTTP timeout for requests to SonarQube, 10s by default",
+        help="HTTP timeout for requests to SonarQube, 10 by default (in seconds)",
     )
     parser.add_argument(
         f"--{SKIP_VERSION_CHECK}",

--- a/sonar/platform.py
+++ b/sonar/platform.py
@@ -85,7 +85,7 @@ class Platform:
         self.__global_nav = None
         self._server_id = None
         self._permissions = None
-        self.http_timeout = http_timeout
+        self.http_timeout = int(http_timeout)
         self.organization = org
         self.__is_sonarcloud = util.is_sonarcloud_url(self.url)
 

--- a/test/test_housekeeper.py
+++ b/test/test_housekeeper.py
@@ -36,6 +36,7 @@ __GOOD_OPTS = [
     [],
     [f"--{options.NBR_THREADS}", "1"],
     ["-P", "30"],
+    ["--httpTimeout", "100"],
 ]
 
 


### PR DESCRIPTION
If the httpTimeout parameter is defined with the value 100, the following error appear:
ValueError: Timeout value connect was 100, but it must be an int, float or None.

How to reproduce:
```
[...]
docker run --rm -it python:3.12-alpine sh -c "pip install sonar-tools==3.2.2 && sonar-housekeeper --token random --httpTimeout 100"
Traceback (most recent call last):
  File "/usr/local/bin/sonar-housekeeper", line 8, in <module>
    sys.exit(main())
             ^^^^^^
  File "/usr/local/lib/python3.12/site-packages/cli/housekeeper.py", line 217, in main
    problems = get_project_problems(proj_age, branch_age, pr_age, kwargs[options.NBR_THREADS], sq)
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.12/site-packages/cli/housekeeper.py", line 61, in get_project_problems
    problems = projects.audit(endpoint=endpoint, audit_settings=settings)
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.12/site-packages/sonar/projects.py", line 1265, in audit
    plist = get_list(endpoint, key_list)
            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.12/site-packages/sonar/projects.py", line 1222, in get_list
    return search(endpoint=endpoint)
           ^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.12/site-packages/sonar/projects.py", line 1201, in search
    return sqobject.search_objects(
           ^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.12/site-packages/sonar/sqobject.py", line 107, in search_objects
    data = json.loads(endpoint.get(api, params=new_params).text)
                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.12/site-packages/sonar/platform.py", line 194, in get
    return self.__run_request(requests.get, api, params, exit_on_error, mute)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.12/site-packages/sonar/platform.py", line 246, in __run_request
    r = request(
        ^^^^^^^^
  File "/usr/local/lib/python3.12/site-packages/requests/api.py", line 73, in get
    return request("get", url, params=params, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.12/site-packages/requests/api.py", line 59, in request
    return session.request(method=method, url=url, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.12/site-packages/requests/sessions.py", line 589, in request
    resp = self.send(prep, **send_kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.12/site-packages/requests/sessions.py", line 703, in send
    r = adapter.send(request, **kwargs)
        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.12/site-packages/requests/adapters.py", line 664, in send
    timeout = TimeoutSauce(connect=timeout, read=timeout)
              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.12/site-packages/urllib3/util/timeout.py", line 115, in __init__
    self._connect = self._validate_timeout(connect, "connect")
                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.12/site-packages/urllib3/util/timeout.py", line 165, in _validate_timeout
    raise ValueError(
ValueError: Timeout value connect was 100, but it must be an int, float or None.
```

After some investigations, I found out that the timeout value is passed threw the **kwargs parameter which is a string dictionary and ignore the parameter definition "http_timeout: int" (https://github.com/okorach/sonar-tools/blob/master/sonar/platform.py#L70) . Casting the http_timeout parameter to int fix the issue.