### PR TITLE
added logic to deactivate rules which are not present in the import

### DIFF
--- a/sonar/qualityprofiles.py
+++ b/sonar/qualityprofiles.py
@@ -265,6 +265,21 @@ class QualityProfile(sq.SqObject):
             return False
         return r.ok
 
+    def deactivate_rule(self, rule_key: str) -> bool:
+        """Deactivates a rule in the quality profile
+
+        :param str rule_key: Rule key to activate
+        :return: Whether the deactivation succeeded
+        :rtype: bool
+        """
+        api_params = {"key": self.key, "rule": rule_key}
+        try:
+            r = self.post("qualityprofiles/deactivate_rule", params=api_params)
+        except (ConnectionError, RequestException) as e:
+            util.handle_error(e, f"deactivating rule {rule_key} in {str(self)}", catch_all=True)
+            return False
+        return r.ok
+
     def activate_rules(self, ruleset: dict[str, str]) -> bool:
         """Activates a list of rules in the quality profile
         :return: Whether the activation of all rules was successful
@@ -280,6 +295,15 @@ class QualityProfile(sq.SqObject):
                 ok = ok and self.activate_rule(rule_key=r_key, severity=sev, **r_data["params"])
             else:
                 ok = ok and self.activate_rule(rule_key=r_key, severity=sev)
+
+        activerules = self.rules()
+        for r_key, r_data in activerules.items():
+            if r_key in ruleset:
+                log.debug("Rule %s exists in quality profile", r_key)
+            else:
+                log.debug("Deactivating rule %s in QG %s", r_key, str(self))
+                self.deactivate_rule(rule_key=r_key)
+
         return ok
 
     def update(self, data: types.ObjectJsonRepr, queue: Queue) -> QualityProfile:


### PR DESCRIPTION
I've expanded the import logic so that it also deactivates the rules which are not present in the import. This is a real use-case which I want to be able to support.

Maybe it could be interesting to do this with a command line flag, but I don't see how I can easily access any command line arguments from this part.