### PR TITLE
Support issue synchronization in MQR mode

### DIFF
--- a/doc/sonar-findings-sync.md
+++ b/doc/sonar-findings-sync.md
@@ -81,10 +81,6 @@ Issues changelog synchronization includes:
 When an issue could not be synchronized because of one of the above reasons, this is reported in the `sonar-findings-sync` report.
 Whenever a close enough issue was found but not sync'ed (because not 100% certain to be identical), the close issue is provided in the report to complete synchronization manually if desired.
 
-## Required Permissions
-
-`sonar-findings-sync` needs the global `Create Projects` permission
-
 ## Configurable behaviors
 
 When an issue is synchronized, a special comment is added on the target issue with a link to the source one, for cross checking purposes. This comment can be disabled by using the `--nolink` option

--- a/sonar/changelog.py
+++ b/sonar/changelog.py
@@ -59,6 +59,10 @@ class Changelog(object):
         """Returns whether the changelog item is an issue resolved as won't fix"""
         return self.__is_resolve_as("WONTFIX")
 
+    def is_resolve_as_accept(self) -> bool:
+        """Returns whether the changelog item is an issue resolved as accepted"""
+        return self.__is_resolve_as("ACCEPTED")
+
     def is_closed(self) -> bool:
         """{'creationDate': '2022-02-01T19:15:24+0100', 'diffs': [
         {'key': 'resolution', 'newValue': 'FIXED'},
@@ -219,6 +223,8 @@ class Changelog(object):
             ctype = ("FALSE-POSITIVE", None)
         elif self.is_resolve_as_wf():
             ctype = ("WONT-FIX", None)
+        elif self.is_resolve_as_accept():
+            ctype = ("ACCEPT", None)
         elif self.is_tag():
             ctype = ("TAG", self.get_tags())
         elif self.is_closed():

--- a/sonar/issues.py
+++ b/sonar/issues.py
@@ -352,8 +352,6 @@ class Issue(findings.Finding):
         :return: Whether the operation succeeded
         :rtype: bool
         """
-        if self.endpoint.is_mqr_mode():
-            raise exceptions.UnsupportedOperation("Setting issue type is not supported in MQR mode")
         log.debug("Changing type of issue %s from %s to %s", self.key, self.type, new_type)
         try:
             r = self.post("issues/set_type", {"issue": self.key, "type": new_type})


### PR DESCRIPTION
After a test, it turned out there were some issues with synchronizing issues statuses (`sonar-issues-sync`) in MQR mode. It was also not possible to synchronize issues from SonarQube Cloud to SonarQube Server.

Fixes #1616 

The 'issueStatus' field in an issue's changelog has been available since SonarQube Server 10.4 and is the preferred method for retrieving information about issue changes. Starting with SonarQube Server 10.4, the "resolution" and "status" keys are deprecated in issue changelogs but remain relevant for security hotspot changelogs. These conditions are retained for backward compatibility to support versions from SQS 9.9 to 10.3, where "resolution" and "status" are the only way to detect status changes. They are also still applicable for security hotspot changelogs.