### PR TITLE
`sonar-tools` displays a blank FATAL message when token is invalid

### DIFF
--- a/sonar/platform.py
+++ b/sonar/platform.py
@@ -301,6 +301,8 @@ class Platform(object):
             code = r.status_code
             lvl = log.DEBUG if code in mute else log.ERROR
             log.log(lvl, "%s (%s request)", util.error_msg(e), req_type)
+            if code == HTTPStatus.UNAUTHORIZED:
+                raise exceptions.SonarException(util.error_msg(e), errcodes.SONAR_API_AUTHENTICATION) from e
             err_msg = util.sonar_error(e.response)
             err_msg_lower = err_msg.lower()
             key = next((params[k] for k in ("key", "project", "component", "componentKey") if k in params), "Unknown")


### PR DESCRIPTION
Fixes #2098