### PR TITLE
add Pull Request option to export LoC for them as well

### DIFF
--- a/cli/options.py
+++ b/cli/options.py
@@ -171,7 +171,12 @@ class ArgumentsError(exceptions.SonarException):
 def __convert_args_to_lists(kwargs: dict[str, str]) -> dict[str, str]:
     """Converts arguments that may be CSV into lists"""
     for argname in MULTI_VALUED_OPTS:
-        if argname in kwargs and kwargs[argname] is not None and len(kwargs[argname]) > 0:
+        if (
+            argname in kwargs
+            and kwargs[argname] is not None
+            and isinstance(kwargs[argname], (str, list))
+            and len(kwargs[argname]) > 0
+        ):
             kwargs[argname] = utilities.csv_to_list(kwargs[argname])
     if kwargs.get(LANGUAGES, None) not in (None, ""):
         kwargs[LANGUAGES] = [lang.lower() for lang in utilities.csv_to_list(kwargs[LANGUAGES])]


### PR DESCRIPTION
This PR implements #2160:
- Adds a --pullRequests (-pr) option to sonar-loc to export Lines of Code (LoC) for pull requests, in addition to projects and branches.
- The CSV output now always includes a "branch or pr" column and a new "type" column to clearly distinguish between project, branch, and PR rows.
- Ensures all rows are grouped by project, and the summary LoC is calculated as the maximum LoC per project (avoiding double-counting from PRs/branches).
- Improves log messages for clarity, reflecting the true number of grouped projects and the correct LoC sum.