### PR TITLE
Update regex to specifically match GitHub URL in sonar settings

### DIFF
--- a/sonar/settings.py
+++ b/sonar/settings.py
@@ -267,7 +267,7 @@ class Setting(SqObject):
             return ok
 
         # With SonarQube 10.x you can't set the github URL
-        if re.match(r"^sonar\.auth\.(.*)[Uu]rl$", self.key) and self.endpoint.version() >= (10, 0, 0):
+        if re.match(r"^sonar\.auth\.github\.(.*)[Uu]rl$", self.key) and self.endpoint.version() >= (10, 0, 0):
             log.warning("GitHub URL (%s) cannot be set, skipping this setting", self.key)
             return False
 


### PR DESCRIPTION
Hi,

Fixed a small typo for a regex matching incorrectly "sonar.auth.saml.loginUrl" resulting in:

[...]
2026-02-04 17:30:13,573 | sonar-config | WARNING | MainThread      | GitHub URL (sonar.auth.saml.loginUrl) cannot be set, skipping this setting
[...]

Regards,
 Joan