### PR TITLE
fix missing API reference api/language/list on cloud.json

### DIFF
--- a/sonar/api/cloud.json
+++ b/sonar/api/cloud.json
@@ -1356,5 +1356,16 @@
             ],
             "return_field": "task"
         }
+    },
+    "Language": {
+        "SEARCH": {
+            "method": "GET",
+            "api": "api/languages/list",
+            "params": [
+                "ps",
+                "q"
+            ],
+            "return_field": "languages"
+        }
     }
 }


### PR DESCRIPTION
Running `sonar-findings-export` fails on SonarQube Cloud with following error:
```
2026-02-06 21:01:05,265 | sonar-findings | INFO    | MainThread      | Writing 358 more findings in format csv
Traceback (most recent call last):
  File "/home/stevan.vanderwerf/.local/share/pipx/venvs/sonar-tools/lib/python3.12/site-packages/cli/findings_export.py", line 326, in store_findings
    __write_findings(found_findings, file, total_findings == 0, **local_params)
...
  File "/home/stevan.vanderwerf/.local/share/pipx/venvs/sonar-tools/lib/python3.12/site-packages/sonar/api/manager.py", line 137, in get_api_entry
    raise UnsupportedOperation(f"API for {class_name} in version {self.endpoint.version()} not found in API definition")
sonar.exceptions.UnsupportedOperation: ERROR 7: API for Language in version (0, 0, 0) not found in API definition
2026-02-06 21:01:05,268 | sonar-findings | ERROR   | MainThread      | Exception ERROR 7: API for Language in version (0, 0, 0) not found in API definition when exporting findings of project 'SupportTeam-SC-demos_dart-samples'.
```
adding `api/languages/list` to `cloud.json` (already exists for `2025.1.json` and `9.9.json`)