### PR TITLE
Bump to 3.19

### DIFF
--- a/conf/release.Dockerfile
+++ b/conf/release.Dockerfile
@@ -28,7 +28,7 @@ COPY ./LICENSE .
 COPY ./sonar/audit sonar/audit
 
 RUN pip install --upgrade pip \
-&& pip install sonar-tools==3.18.3
+&& pip install sonar-tools==3.19
 
 USER ${USERNAME}
 WORKDIR /home/${USERNAME}

--- a/doc/what-is-new.md
+++ b/doc/what-is-new.md
@@ -1,5 +1,7 @@
 # Next version
 
+# Version 3.18.3
+
 # Version 3.18.2
 
 * Fix issue https://github.com/okorach/sonar-tools/issues/2262: `sonar-findings-export` failing on SonarQube cloud 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "sonar-tools"
-version = "3.18.3"
+version = "3.19"
 description = "A collection of utility tools for the SonarQube ecosystem"
 authors = [
   {name = "Olivier Korach", email = "olivier.korach@gmail.com"},


### PR DESCRIPTION
* Improve logs (#2270)

* Fixes #2271 (#2272)

* Fix-2274 (#2275)

* Fixes #2274

* Reduce complexity

* Fixes #2276 #2269

* Quality-pass (#2277)

* Fix tests

* Quality pass

* Better slicing

* last fixes (#2280)

* Fix-tests (#2282)

* FIx unbound var

* Adjust test

* Adjuts test

* Fix when brnch or PR regexp is set

* Fix test

* Fix test on LTA / LATEST

* Quality pass

* Improve msg when too many facets (#2284)

* Add clear message when findings-export can't export due to too many facets

* Improve error message when too many facets

* Fixes #2289 (#2290)

* Bump/3.18.3 (#2291)

* Bump version

* Bump version to 3.18.3

* Fix search by fileUuid on SQC instead of file (#2293)

* Fix search by fileUuid instead of file on SQC

* Bump version

* Fix-search-by-fileuuid-facet-on-sqc (#2294)

* Fix search by fileUuid instead of file on SQC

* Bump version

* Fix sync when issues come from api/projects/export_findings where the has h is in available upfront

* Remove closed issues from the sync upfront

* Merge branch '3.18.x' into fix-search-by-fileuuid-facet-on-sqc

---------

Co-authored-by: Olivier K <161828284+okorach-sonar@users.noreply.github.com> Co-authored-by: Olivier Korach <olivier.korach@sonarsource.com>