### PR TITLE
Fixes #2288 - Add new legit QG metrics

### DIFF
--- a/sonar/qualitygates.py
+++ b/sonar/qualitygates.py
@@ -98,6 +98,8 @@ GOOD_QG_CONDITIONS = {
     "software_quality_blocker_issues": (0, 0, __MAX_ISSUES_SHOULD_BE_ZERO),
     "software_quality_high_issues": (0, 0, __MAX_ISSUES_SHOULD_BE_ZERO),
     "prioritized_rule_issues": (0, 0, __MAX_ISSUES_SHOULD_BE_ZERO),
+    "sca_count_malware": (0, 0, "Malware count on overall code should always be 0"),
+    "security_hotspots_reviewed": (1, 50, "Security hotspots reviewed on overall code should be between 1% and 50%"),
 }
 
 _IMPORTABLE_PROPERTIES = ("name", "isDefault", "isBuiltIn", "conditions", "permissions")


### PR DESCRIPTION
## Summary
- Adds `sca_count_malware` (max value 0) and `security_hotspots_reviewed` (range 1%-50%) to the `GOOD_QG_CONDITIONS` dictionary
- These are new metrics recently added in SonarQube that are legitimate in quality gates but were incorrectly flagged as audit problems

## Test plan
- [ ] Run `sonar-audit` against a SonarQube instance with a quality gate using `sca_count_malware` and `security_hotspots_reviewed` conditions
- [ ] Verify no false audit problems are raised for these metrics
- [ ] Verify out-of-range values still trigger audit problems

Closes #2288

🤖 Generated with [Claude Code](https://claude.com/claude-code)