### PR TITLE
Fixes #2214 - Support multiple webhooks with same name

### DIFF
--- a/sonar/platform.py
+++ b/sonar/platform.py
@@ -482,11 +482,9 @@ class Platform(object):
                 setting_json[s.key].pop("value")
             sutil.update_json(json_data, categ, subcateg, setting_json)
 
-        hooks = {}
+        hooks = []
         for wb in self.webhooks().values():
-            j = util.remove_nones(wb.to_json(full))
-            j.pop("name", None)
-            hooks[wb.name] = j
+            hooks.append(util.remove_nones(wb.to_json(full)))
         if len(hooks) > 0:
             json_data["webhooks"] = hooks
         json_data["permissions"] = self.global_permissions().export(export_settings=export_settings)

--- a/sonar/webhooks.py
+++ b/sonar/webhooks.py
@@ -199,11 +199,9 @@ class WebHook(SqObject):
 
 def export(endpoint: Platform, project_key: Optional[str] = None, full: bool = False) -> ObjectJsonRepr:
     """Export webhooks of a project as JSON"""
-    json_data = {}
+    json_data = []
     for wb in WebHook.search(endpoint, project=project_key).values():
-        j = wb.to_json(full)
-        j.pop("name", None)
-        json_data[wb.name] = util.remove_nones(j)
+        json_data.append(util.remove_nones(wb.to_json(full)))
     return json_data if len(json_data) > 0 else None
 
 
@@ -211,13 +209,14 @@ def import_config(endpoint: Platform, data: list[dict[str, str]], project_key: O
     """Imports a set of webhooks defined from a JSON description"""
     log.info("Importing webhooks %s for %s", str(data), str(project_key))
     current_wh = WebHook.search(endpoint, project=project_key)
-    existing_webhooks = {wh.name: k for k, wh in current_wh.items()}
+    existing_by_name: dict[str, list[str]] = {}
+    for k, wh in current_wh.items():
+        existing_by_name.setdefault(wh.name, []).append(k)
 
-    # FIXME: Handle several webhooks with same name
     for wh_data in data:
         wh_name = wh_data["name"]
-        if wh_name in existing_webhooks:
-            current_wh[existing_webhooks[wh_name]].update(**wh_data)
+        if wh_name in existing_by_name and existing_by_name[wh_name]:
+            current_wh[existing_by_name[wh_name].pop(0)].update(**wh_data)
         else:
             hook = WebHook.create(endpoint=endpoint, name=wh_name, url=wh_data.get("url", "https://to.be.defined"), project=project_key)
             hook.update(**wh_data)

--- a/test/unit/test_webhooks.py
+++ b/test/unit/test_webhooks.py
@@ -81,9 +81,9 @@ def test_update() -> None:
 def test_export() -> None:
     """test_export"""
     exp = wh.export(tutil.SQ)
-    assert len(exp) == 1
-    first = list(exp.keys())[0]
-    assert exp[first]["url"].startswith("https://")
+    assert len(exp) >= 1
+    assert "name" in exp[0]
+    assert "url" in exp[0]
 
 
 def test_create_delete() -> None:


### PR DESCRIPTION
## Summary
- Export webhooks as lists instead of dicts keyed by name, which silently dropped duplicates when multiple webhooks shared the same name
- Fix import matching to use FIFO per-name lookup so each duplicate is correctly matched to an existing webhook
- Update test assertions for the new list-based export format

## Test plan
- [x] `pytest test/unit/test_webhooks.py::test_export` passes
- [ ] Verify export of a platform with duplicate-named webhooks produces a list with all entries
- [ ] Verify import correctly updates each duplicate-named webhook individually

🤖 Generated with [Claude Code](https://claude.com/claude-code)