### PR TITLE
Fixes #2197 - Add Application.remove_project() method

### DIFF
--- a/sonar/applications.py
+++ b/sonar/applications.py
@@ -349,6 +349,26 @@ class Application(aggr.Aggregation):
         self.projects()
         return ok
 
+    def remove_project(self, project: Union[projects.Project, str]) -> bool:
+        """Remove a project from an application
+
+        :param project: Project object or project key string
+        :return: Whether the operation succeeded
+        """
+        proj_key = self.__class__.get_key(project)
+        log.debug("Removing project '%s' from %s", proj_key, str(self))
+        try:
+            api, _, params, _ = self.endpoint.api.get_details(self, Oper.REMOVE_PROJECT, application=self.key, project=proj_key)
+            r = self.endpoint.post(api, params=params)
+            ok = r.ok
+        except (ConnectionError, RequestException) as e:
+            sutil.handle_error(e, f"removing project '{proj_key}' from {self}", catch_http_statuses=(HTTPStatus.NOT_FOUND,))
+            self.__class__.CACHE.pop(self)
+            ok = False
+        self._projects = None
+        self.projects()
+        return ok
+
     def recompute(self) -> bool:
         """Triggers application recomputation, return whether the operation succeeded"""
         log.debug("Recomputing %s", str(self))

--- a/test/unit/test_apps.py
+++ b/test/unit/test_apps.py
@@ -335,6 +335,18 @@ def test_app_branches(get_test_app: Generator[App]) -> None:
     assert obj.main_branch().name == APP_BRANCH_MAIN
 
 
+def test_remove_project(get_test_app: Generator[App]) -> None:
+    """Test removing a project from an application"""
+    if not __verify_support():
+        pytest.skip(__UNSUPPORTED_MESSAGE)
+    obj: App = get_test_app
+    proj_key = tutil.PROJECT_1
+    assert obj.add_projects([proj_key])
+    assert proj_key in obj.projects()
+    assert obj.remove_project(proj_key)
+    assert proj_key not in obj.projects()
+
+
 def test_sorted_search() -> None:
     """test_sorted_search"""
     if not __verify_support():


### PR DESCRIPTION
## Summary
- Add `Application.remove_project()` method that wraps the `api/applications/remove_project` SonarQube API
- Accepts either a `Project` object or a project key string (uses `SqObject.get_key()` for resolution)
- Add unit test `test_remove_project` that verifies add then remove workflow

## Test plan
- [ ] Run `pytest test/unit/test_apps.py::test_remove_project -v`
- [ ] Verify removing a project that is in the application succeeds
- [ ] Verify passing a Project object works the same as passing a string key

🤖 Generated with [Claude Code](https://claude.com/claude-code)