### PR TITLE
Fixes #2322 - Fix sonar-loc total LoC always showing 0

### DIFF
--- a/cli/loc.py
+++ b/cli/loc.py
@@ -76,14 +76,13 @@ def __dump_csv(object_list: list[object], file: str, **kwargs: Any) -> None:
         writer.writerow(__get_csv_header_list(**kwargs))
 
         for o in object_list:
-            arr, _ = __get_csv_row(o, **kwargs)
+            arr, obj_ncloc = __get_csv_row(o, **kwargs)
             writer.writerow(arr)
             nb_objects += 1
-            # arr[0] is project key, arr[3] (or arr[-1] if columns change) is ncloc
             project_key = arr[0]
             try:
-                ncloc = int(arr[3])
-            except (ValueError, IndexError):
+                ncloc = int(obj_ncloc)
+            except (ValueError, TypeError):
                 ncloc = 0
             if project_key not in project_max_loc or ncloc > project_max_loc[project_key]:
                 project_max_loc[project_key] = ncloc
@@ -126,26 +125,37 @@ def __get_object_json_data(o: object, **kwargs: Any) -> dict[str, str]:
 def __dump_json(object_list: list[object], file: str, **kwargs: Any) -> None:
     """Dumps LoC of passed list of objects (projects, branches or portfolios) as JSON"""
     nb_loc, nb_objects = 0, 0
+    project_max_loc = {}
     data = []
     if len(object_list) <= 0:
         log.warning("No objects with LoCs to dump, dump skipped")
         return
     obj_type = type(object_list[0]).__name__.lower()
+    parent_type = kwargs[options.COMPONENT_TYPE][:-1]
     # Collect all objects data
     for o in object_list:
-        data.append(__get_object_json_data(o, **kwargs))
+        obj_data = __get_object_json_data(o, **kwargs)
+        data.append(obj_data)
         nb_objects += 1
+        try:
+            ncloc = int(obj_data["ncloc"])
+        except (ValueError, TypeError):
+            ncloc = 0
+        project_key = obj_data[parent_type]
+        if project_key not in project_max_loc or ncloc > project_max_loc[project_key]:
+            project_max_loc[project_key] = ncloc
         if nb_objects % 50 != 0:
             continue
         if obj_type == "project":
-            log.info("%d %ss and %d LoCs, still counting...", nb_objects, str(obj_type), nb_loc)
+            log.info("%d %ss and %d LoCs, still counting...", nb_objects, str(obj_type), sum(project_max_loc.values()))
         else:
             log.info("%d %ss dumped, still counting...", nb_objects, str(obj_type))
 
+    nb_loc = sum(project_max_loc.values())
     with util.open_file(file) as fd:
         print(util.json_dump(data), file=fd)
     if obj_type == "project":
-        log.info("%d %ss and %d LoCs in total", len(object_list), str(obj_type), nb_loc)
+        log.info("%d %ss and %d LoCs in total", len(project_max_loc), str(obj_type), nb_loc)
     else:
         log.info("%d %ss dumped in total", len(object_list), str(obj_type))
 


### PR DESCRIPTION
## Summary
- **CSV path (`__dump_csv`):** The ncloc value returned by `__get_csv_row()` was discarded (`arr, _ = ...`) and instead read from `arr[3]` which is the PR column (not ncloc at index 4). `int("")` always failed, defaulting to 0.
- **JSON path (`__dump_json`):** `nb_loc` was initialized to 0 but never updated in the loop — no LoC accumulation happened at all.
- Both paths now properly track LoCs per project using a `project_max_loc` dictionary and sum them for the final log message.

Fixes #2322

## Test plan
- [ ] Run `sonar-loc` in CSV mode and verify the final log line shows the correct total LoC count
- [ ] Run `sonar-loc` in JSON mode and verify the final log line shows the correct total LoC count
- [ ] Run with `--branches` to verify multi-branch grouping still works correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)