### PR TITLE
Update GitHub Actions to latest versions (Node 24)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -18,11 +18,11 @@ jobs:
     #    python-version: [2.7, 3.5, 3.6, 3.7, 3.8]
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: '3.9'
       - name: Install dependencies
@@ -60,7 +60,7 @@ jobs:
           version=$(grep PACKAGE_VERSION sonar/version.py | cut -d "=" -f 2 | sed "s/[\'\" ]//g")
           echo "sonar.projectVersion=$version" >> sonar-project.properties
       - name: SonarQube Cloud scan
-        uses: SonarSource/sonarqube-scan-action@master
+        uses: SonarSource/sonarqube-scan-action@v7
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}  # Needed to get PR information, if any
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}


### PR DESCRIPTION
## Summary
- Update `actions/checkout` from v4 to v6
- Update `actions/setup-python` from v5 to v6
- Update `SonarSource/sonarqube-scan-action` from `@master` to v7
- All actions now run on Node.js 24, replacing the deprecated Node 20 runtime

## Test plan
- [ ] Verify the CI pipeline runs successfully on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)