### PR TITLE
Refactor get_object() to use cache only optionally

### DIFF
--- a/sonar/app_branches.py
+++ b/sonar/app_branches.py
@@ -67,11 +67,12 @@ class ApplicationBranch(Component):
         log.debug("Constructed object %s with uuid %d id %x", str(self), hash(self), id(self))
 
     @classmethod
-    def get_object(cls, endpoint: Platform, app: Union[str, apps.Application], branch_name: str) -> ApplicationBranch:
+    def get_object(cls, endpoint: Platform, app: Union[str, apps.Application], branch_name: str, use_cache: bool = True) -> ApplicationBranch:
         """Gets an Application object from SonarQube
 
         :param str | Application app: Reference to the Application holding that branch
         :param branch_name: Name of the application branch
+        :param use_cache: Whether to use cached object, default True
         :raises ObjectNotFound: If Application or Brnach not found
         :return: The found ApplicationBranch object
         """
@@ -79,7 +80,7 @@ class ApplicationBranch(Component):
             raise exceptions.UnsupportedOperation(_NOT_SUPPORTED)
         if isinstance(app, str):
             app = apps.Application.get_object(endpoint, app)
-        if o := cls.CACHE.get(endpoint.local_url, app.key, branch_name):
+        if use_cache and (o := cls.CACHE.get(endpoint.local_url, app.key, branch_name)):
             return o
         app.refresh()
         app.branches()

--- a/sonar/applications.py
+++ b/sonar/applications.py
@@ -75,11 +75,12 @@ class Application(aggr.Aggregation):
         return f"application key '{self.key}'"
 
     @classmethod
-    def get_object(cls, endpoint: Platform, key: str) -> Application:
+    def get_object(cls, endpoint: Platform, key: str, use_cache: bool = True) -> Application:
         """Gets an Application object from SonarQube
 
         :param Platform endpoint: Reference to the SonarQube platform
         :param str key: Application key, must not already exist on SonarQube
+        :param bool use_cache: Whether to use cached object, default True
         :raises UnsupportedOperation: If on a Community Edition
         :raises ObjectNotFound: If Application key not found in SonarQube
         :return: The found Application object
@@ -87,7 +88,7 @@ class Application(aggr.Aggregation):
         """
         check_supported(endpoint)
         o: Optional[Application] = cls.CACHE.get(endpoint.local_url, key)
-        if o:
+        if o and use_cache:
             return o
         api, _, params, ret = endpoint.api.get_details(cls, Oper.GET, application=key)
         data = json.loads(endpoint.get(api, params=params).text)[ret]

--- a/sonar/devops.py
+++ b/sonar/devops.py
@@ -73,9 +73,9 @@ class DevopsPlatform(SqObject):
         return string
 
     @classmethod
-    def get_object(cls, endpoint: Platform, key: str) -> DevopsPlatform:
+    def get_object(cls, endpoint: Platform, key: str, use_cache: bool = True) -> DevopsPlatform:
         """Reads a devops platform object in Sonar instance"""
-        if o := cls.CACHE.get(endpoint.local_url, key):
+        if use_cache and (o := cls.CACHE.get(endpoint.local_url, key)):
             return o
         cls.search(endpoint)
         if o := cls.CACHE.get(endpoint.local_url, key):

--- a/sonar/findings.py
+++ b/sonar/findings.py
@@ -146,10 +146,10 @@ class Finding(SqObject):
         self.reload(data, from_export)
 
     @classmethod
-    def get_object(cls, endpoint: Platform, data: ApiPayload, from_export: bool = False) -> IssueOrHotspot:
+    def get_object(cls, endpoint: Platform, data: ApiPayload, from_export: bool = False, use_cache: bool = True) -> IssueOrHotspot:
         """Returns a finding from its key"""
         o: Optional[IssueOrHotspot] = cls.CACHE.get(endpoint.local_url, data["key"])
-        if not o:
+        if not o or not use_cache:
             o = cls(endpoint, data, from_export=from_export)
         return o
 

--- a/sonar/license_profiles.py
+++ b/sonar/license_profiles.py
@@ -91,18 +91,19 @@ class LicenseProfile(SqObject):
         return (self.name,)
 
     @classmethod
-    def get_object(cls, endpoint: Platform, name: str) -> LicenseProfile:
+    def get_object(cls, endpoint: Platform, name: str, use_cache: bool = True) -> LicenseProfile:
         """Gets a license profile by name
 
         :param endpoint: Reference to the SonarQube platform
         :param name: License profile name
+        :param use_cache: Whether to use cached object, default True
         :return: the LicenseProfile object
         :raises ObjectNotFound: if not found
         :raises UnsupportedOperation: if platform version is too old
         """
         _check_supported(endpoint)
         o: Optional[LicenseProfile] = cls.CACHE.get(endpoint.local_url, name)
-        if o:
+        if o and use_cache:
             return o
         # Search all profiles and try to find by name
         all_profiles = cls.search(endpoint)

--- a/sonar/organizations.py
+++ b/sonar/organizations.py
@@ -77,11 +77,12 @@ class Organization(SqObject):
         return cls.get_paginated(endpoint=endpoint, params=search_params | {"member": "true"})
 
     @classmethod
-    def get_object(cls, endpoint: Platform, key: str) -> Organization:
+    def get_object(cls, endpoint: Platform, key: str, use_cache: bool = True) -> Organization:
         """Gets an Organization object from SonarQube Cloud
 
         :param Platform endpoint: Reference to the SonarQube platform
         :param str key: Application key, must not already exist on SonarQube
+        :param use_cache: Whether to use cached object, default True
         :raises UnsupportedOperation: If on a Community Edition
         :raises ObjectNotFound: If Application key not found in SonarQube
         :return: The found Application object
@@ -89,7 +90,7 @@ class Organization(SqObject):
         """
         if not endpoint.is_sonarcloud():
             raise exceptions.UnsupportedOperation(_NOT_SUPPORTED)
-        if o := Organization.CACHE.get(endpoint.local_url, key):
+        if use_cache and (o := Organization.CACHE.get(endpoint.local_url, key)):
             return o
         api, _, params, ret = endpoint.api.get_details(cls, Oper.SEARCH, organizations=key)
         data = json.loads(endpoint.get(api, params=params).text)

--- a/sonar/permissions/permission_templates.py
+++ b/sonar/permissions/permission_templates.py
@@ -212,9 +212,9 @@ class PermissionTemplate(sqobject.SqObject):
         return self._audit_pattern(audit_settings) + self.permissions().audit(audit_settings)
 
     @classmethod
-    def get_object(cls, endpoint: Platform, name: str) -> PermissionTemplate:
+    def get_object(cls, endpoint: Platform, name: str, use_cache: bool = True) -> PermissionTemplate:
         """Returns Perm Template object corresponding to name"""
-        if len(cls.CACHE.from_platform(endpoint)) == 0:
+        if len(cls.CACHE.from_platform(endpoint)) == 0 or not use_cache:
             cls.search(endpoint)
         return cls.CACHE.get(endpoint.local_url, name.lower())
 

--- a/sonar/portfolio_reference.py
+++ b/sonar/portfolio_reference.py
@@ -52,7 +52,7 @@ class PortfolioReference(SqObject):
         log.debug("Created subportfolio by reference key '%s'", self.key)
 
     @classmethod
-    def get_object(cls, endpoint: Platform, key: str, parent_key: str) -> PortfolioReference:
+    def get_object(cls, endpoint: Platform, key: str, parent_key: str, use_cache: bool = True) -> PortfolioReference:
         """Gets a subportfolio by reference object from its key and parent"""
         check_supported(endpoint)
         log.info("Getting subportfolio by ref key '%s:%s'", parent_key, key)

--- a/sonar/portfolios.py
+++ b/sonar/portfolios.py
@@ -122,12 +122,12 @@ class Portfolio(aggregations.Aggregation):
         return dict(sorted(cls.get_paginated(endpoint=endpoint, params=search_params).items()))
 
     @classmethod
-    def get_object(cls, endpoint: Platform, key: str) -> Portfolio:
+    def get_object(cls, endpoint: Platform, key: str, use_cache: bool = True) -> Portfolio:
         """Gets a portfolio object from its key"""
         check_supported(endpoint)
         log.debug("Getting portfolio object key '%s'", key)
         o = cls.CACHE.get(endpoint.local_url, key)
-        if o:
+        if o and use_cache:
             log.debug("%s is in cache", str(o))
             return o
         log.debug("Portfolio key '%s' not in cache, searching it", key)

--- a/sonar/qualitygates.py
+++ b/sonar/qualitygates.py
@@ -146,15 +146,16 @@ class QualityGate(SqObject):
         return (self.name,)
 
     @classmethod
-    def get_object(cls, endpoint: Platform, name: str) -> QualityGate:
+    def get_object(cls, endpoint: Platform, name: str, use_cache: bool = True) -> QualityGate:
         """Reads a quality gate from SonarQube
 
         :param endpoint: Reference to the SonarQube platform
         :param name: Quality gate
+        :param use_cache: Whether to use cached object, default True
         :return: the QualityGate object or None if not found
         """
         o: Optional[QualityGate] = cls.CACHE.get(endpoint.local_url, name)
-        if o:
+        if o and use_cache:
             log.debug("QG CACHE HIT")
             return o
         log.debug("QG CACHE NO HIT search %s from %s", name, [qg.name for qg in cls.CACHE.values()])

--- a/sonar/rules.py
+++ b/sonar/rules.py
@@ -201,17 +201,18 @@ class Rule(SqObject):
         return f"rule key '{self.key}'"
 
     @classmethod
-    def get_object(cls, endpoint: Platform, key: str) -> Rule:
+    def get_object(cls, endpoint: Platform, key: str, use_cache: bool = True) -> Rule:
         """Returns a rule object from it key
 
         :param endpoint: The SonarQube reference
         :param key: The rule key
+        :param use_cache: Whether to use cached object, default True
         :return: The Rule object corresponding to the input rule key
         :raises: ObjectNotFound if rule does not exist
         """
         if len(cls.CACHE.from_platform(endpoint)) == 0:
             cls.search(endpoint, threads=8, use_cache=False, include_external=True)
-        if o := cls.CACHE.get(endpoint.local_url, key):
+        if use_cache and (o := cls.CACHE.get(endpoint.local_url, key)):
             return o
         cls.get_paginated(endpoint=endpoint, params={"include_external": True, "q": key})
         if o := cls.CACHE.get(endpoint.local_url, key):

--- a/sonar/users.py
+++ b/sonar/users.py
@@ -122,17 +122,18 @@ class User(SqObject):
         return cls.get_paginated(endpoint=endpoint, params=search_params)
 
     @classmethod
-    def get_object(cls, endpoint: Platform, login: Optional[str] = None, id: Optional[str] = None) -> User:
+    def get_object(cls, endpoint: Platform, login: Optional[str] = None, id: Optional[str] = None, use_cache: bool = True) -> User:
         """Creates a User object corresponding to the user with same login in SonarQube
 
         :param Platform endpoint: Reference to the SonarQube platform
         :param login: User login (SonarQube 10.3 and lower)
         :param id: User id (SonarQube 10.4 and above)
+        :param use_cache: Whether to use cached object, default True
         :raises ObjectNotFound: if login not found
         :return: The user object
         :rtype: User
         """
-        if o := cls.CACHE.get(endpoint.local_url, login):
+        if use_cache and (o := cls.CACHE.get(endpoint.local_url, login)):
             return o
         if id is not None:
             return cls.get_object_by_id(endpoint, id)


### PR DESCRIPTION
## Summary
- Adds `use_cache: bool = True` parameter to all `get_object()` class methods that were missing it
- When `use_cache=False`, cache lookup is skipped and data is fetched fresh from the API
- Fully backward-compatible since the parameter defaults to `True`

Fixes #2222

## Changed files (12)
`Portfolio`, `Application`, `QualityGate`, `Rule`, `User`, `Finding`, `ApplicationBranch`, `LicenseProfile`, `DevopsPlatform`, `PortfolioReference`, `Organization`, `PermissionTemplate`

## Test plan
- [x] All existing callers unaffected (default `use_cache=True`)
- [ ] Verify linters pass
- [ ] Verify existing tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)