### PR TITLE
Fix Users API definition for SonarQube Cloud

### DIFF
--- a/sonar/api/cloud.json
+++ b/sonar/api/cloud.json
@@ -322,12 +322,15 @@
     "User": {
         "GET": {
             "method": "GET",
-            "api": "api/users/search",
+            "api": "api/v2/users-management/users",
             "params": [
                 "ids",
-                "p",
-                "ps",
-                "q"
+                "q",
+                "email",
+                "organizationIds",
+                "groupId",
+                "pageIndex",
+                "pageSize"
             ],
             "return_field": "users",
             "page_field": "pageIndex",
@@ -335,12 +338,16 @@
         },
         "SEARCH": {
             "method": "GET",
-            "api": "api/users/search",
+            "api": "api/v2/users-management/users",
             "params": [
                 "ids",
-                "p",
-                "ps",
-                "q"
+                "q",
+                "email",
+                "organizationIds",
+                "groupId",
+                "notInGroupId",
+                "pageIndex",
+                "pageSize"
             ],
             "return_field": "users",
             "page_field": "pageIndex",

--- a/sonar/users.py
+++ b/sonar/users.py
@@ -175,7 +175,10 @@ class User(SqObject):
         if "local" in data:
             self.is_local = data["local"]
         self.last_login = None  #: User last login - read-only
-        if self.endpoint.version() < c.USER_API_V2_INTRO_VERSION:
+        if self.endpoint.is_sonarcloud():
+            self.last_login = sutil.string_to_datetime(data.get("lastConnectionDate"))
+            self.user_id = data.get("id")
+        elif self.endpoint.version() < c.USER_API_V2_INTRO_VERSION:
             self.last_login = sutil.string_to_datetime(data.get("lastConnectionDate"))
             self.nb_tokens = data.get("tokenCount")  #: Nbr of tokens - read-only
         else:


### PR DESCRIPTION
## Summary
- Updates cloud.json User API from old v1 (api/users/search) to v2 (api/v2/users-management/users)
- Replaces legacy pagination params (p, ps) with v2 params (pageIndex, pageSize)
- Adds new v2 query params: email, organizationIds, groupId, notInGroupId
- Adds SonarCloud-specific handling in reload() to capture user id from v2 response

Fixes #2194

## Test plan
- [ ] Verify SonarCloud user search works with new v2 API
- [ ] Verify user last connection date is correctly parsed
- [ ] Verify user id is captured from Cloud API response

Generated with [Claude Code](https://claude.com/claude-code)