### PR TITLE
Fix Group API calls for SonarQube Cloud (#2195)

### DIFF
--- a/sonar/api/cloud.json
+++ b/sonar/api/cloud.json
@@ -372,7 +372,8 @@
     "Group": {
         "CREATE": {
             "method": "POST",
-            "api": "api/user_groups/create",
+            "api": "api/v2/authorizations/groups",
+            "content_type": "application/json",
             "params": [
                 "name",
                 "description"
@@ -380,71 +381,60 @@
         },
         "GET": {
             "method": "GET",
-            "api": "api/user_groups/search",
-            "params": [
-                "q",
-                "p",
-                "ps"
-            ],
-            "return_field": "groups"
+            "api": "api/v2/authorizations/groups/{id}",
+            "return_field": ""
         },
         "UPDATE": {
-            "method": "POST",
-            "api": "api/user_groups/update",
+            "method": "PATCH",
+            "api": "api/v2/authorizations/groups/{id}",
+            "content_type": "application/merge-patch+json",
             "params": [
-                "currentName",
                 "name",
                 "description"
             ]
         },
         "DELETE": {
-            "method": "POST",
-            "api": "api/user_groups/delete",
-            "params": [
-                "name"
-            ]
+            "method": "DELETE",
+            "api": "api/v2/authorizations/groups/{id}"
         },
         "SEARCH": {
             "method": "GET",
-            "api": "api/user_groups/search",
+            "api": "api/v2/authorizations/groups",
             "params": [
                 "q",
-                "p",
-                "ps"
+                "pageIndex",
+                "pageSize"
             ],
-            "page_field": "p",
+            "page_field": "pageIndex",
             "return_field": "groups",
             "max_page_size": 500
         },
         "LIST_MEMBERS": {
             "method": "GET",
-            "api": "api/user_groups/users",
+            "api": "api/v2/authorizations/group-memberships",
             "params": [
-                "name",
-                "p",
-                "ps",
-                "q",
-                "selected"
+                "userId",
+                "groupId",
+                "pageIndex",
+                "pageSize"
             ],
-            "page_field": "p",
-            "return_field": "users",
+            "page_field": "pageIndex",
+            "return_field": "groupMemberships",
             "max_page_size": 500
         },
         "ADD_USER": {
             "method": "POST",
-            "api": "api/user_groups/add_user",
+            "api": "api/v2/authorizations/group-memberships",
+            "content_type": "application/json",
             "params": [
-                "login",
-                "name"
-            ]
+                "groupId",
+                "userId"
+            ],
+            "return_field": "groupMemberships"
         },
         "REMOVE_USER": {
-            "method": "POST",
-            "api": "api/user_groups/remove_user",
-            "params": [
-                "login",
-                "name"
-            ]
+            "method": "DELETE",
+            "api": "api/v2/authorizations/group-memberships/{id}"
         }
     },
     "Metric": {

--- a/sonar/groups.py
+++ b/sonar/groups.py
@@ -191,7 +191,7 @@ class Group(SqObject):
             # TODO: handle pagination
             api, _, params, ret = self.endpoint.api.get_details(self, Oper.LIST_MEMBERS, groupId=self.group_id, ps=500, pageSize=500, name=self.name)
             data = json.loads(self.endpoint.get(api, params=params).text)[ret]
-            if self.endpoint.version() >= c.GROUP_API_V2_INTRO_VERSION:
+            if self.endpoint.is_sonarcloud() or self.endpoint.version() >= c.GROUP_API_V2_INTRO_VERSION:
                 pname = "id"
                 fname = "userId"
             else:
@@ -209,7 +209,7 @@ class Group(SqObject):
         :param user: the User to get the membership of
         :return: the membership id of the user in the group
         """
-        if self.endpoint.version() < c.GROUP_API_V2_INTRO_VERSION:
+        if not self.endpoint.is_sonarcloud() and self.endpoint.version() < c.GROUP_API_V2_INTRO_VERSION:
             return None
         api, _, params, ret = self.endpoint.api.get_details(self, Oper.LIST_MEMBERS, groupId=self.group_id, userId=user.user_id)
         data = json.loads(self.endpoint.get(api, params=params).text)[ret]
@@ -242,7 +242,7 @@ class Group(SqObject):
             raise exceptions.UnsupportedOperation(f"{user} not in {self}")
         mb_id = self.__get_membership_id(user)
         api, method, params, _ = self.endpoint.api.get_details(self, Oper.REMOVE_USER, id=mb_id, login=user.login, name=self.name)
-        if self.endpoint.version() >= c.GROUP_API_V2_INTRO_VERSION and not mb_id:
+        if (self.endpoint.is_sonarcloud() or self.endpoint.version() >= c.GROUP_API_V2_INTRO_VERSION) and not mb_id:
             raise exceptions.ObjectNotFound(user.login, f"{self} or user id '{user.user_id}' not found")
         if method == "DELETE":
             return self.endpoint.delete(api=api, params=params).ok
@@ -324,7 +324,7 @@ def audit(endpoint: Platform, audit_settings: ConfigSettings, **kwargs: Any) -> 
 
 def get_object_from_id(endpoint: Platform, group_id: str) -> Group:
     """Searches a Group object from its id - SonarQube 10.4+"""
-    if endpoint.version() < c.GROUP_API_V2_INTRO_VERSION:
+    if not endpoint.is_sonarcloud() and endpoint.version() < c.GROUP_API_V2_INTRO_VERSION:
         raise exceptions.UnsupportedOperation("Operation unsupported before SonarQube 10.4")
     if name := Group.ID_TO_NAME.get(group_id):
         return Group.get_object(endpoint, name=name)

--- a/sonar/users.py
+++ b/sonar/users.py
@@ -153,9 +153,16 @@ class User(SqObject):
         :return: The user object
         :rtype: User
         """
-        if endpoint.version() < c.USER_API_V2_INTRO_VERSION:
+        if not endpoint.is_sonarcloud() and endpoint.version() < c.USER_API_V2_INTRO_VERSION:
             raise exceptions.UnsupportedOperation("Get by ID is an APIv2 features, staring from SonarQube 10.4")
         log.debug("Getting user id '%s'", user_id)
+        if endpoint.is_sonarcloud():
+            api, _, params, ret = endpoint.api.get_details(cls, Oper.GET, ids=user_id)
+            data = json.loads(endpoint.get(api, params=params, mute=()).text)
+            users_list = data.get(ret, [])
+            if not users_list:
+                raise exceptions.ObjectNotFound(user_id, f"User id '{user_id}' not found")
+            return cls.load(endpoint, users_list[0])
         api, _, params, _ = endpoint.api.get_details(cls, Oper.GET, id=user_id)
         data = json.loads(endpoint.get(api, params=params, mute=()).text)
         return cls.load(endpoint, data)


### PR DESCRIPTION
## Summary
- Updated `sonar/api/cloud.json` Group section from v1 API (`api/user_groups/*`) to v2 API (`api/v2/authorizations/groups`, `api/v2/authorizations/group-memberships`)
- Added `is_sonarcloud()` checks in `sonar/groups.py` at 4 locations where version checks incorrectly treated Cloud as pre-v2
- Updated `sonar/users.py` `get_object_by_id()` to support SonarCloud by searching with `ids` parameter instead of raising UnsupportedOperation

## Test plan
- [x] JSON validation passes
- [x] Ruff lint check passes (no new errors)
- [x] Unit tests pass (28/28 in test_groups.py + test_users.py)

🤖 Generated with [Claude Code](https://claude.com/claude-code)