### PR TITLE
Move SonarQube Server to bearer authentication (#1034)

### DIFF
--- a/sonar/platform.py
+++ b/sonar/platform.py
@@ -271,14 +271,13 @@ class Platform(object):
             params = [(v[0], str(v[1]).lower() if isinstance(v[1], bool) else v[1]) for v in params]
         headers["Authorization"] = f"Bearer {self.__token}"
         with_org = kwargs.pop("with_organization", True)
-        if self.is_sonarcloud():
-            if with_org:
-                if isinstance(params, dict):
-                    params["organization"] = self.organization
-                elif isinstance(params, (list, tuple)):
-                    params.append(("organization", self.organization))
-                elif isinstance(params, str):
-                    params += f"&organization={self.organization}"
+        if self.is_sonarcloud() and with_org:
+            if isinstance(params, dict):
+                params["organization"] = self.organization
+            elif isinstance(params, (list, tuple)):
+                params.append(("organization", self.organization))
+            elif isinstance(params, str):
+                params += f"&organization={self.organization}"
         req_type, url = getattr(request, "__name__", repr(request)).upper(), ""
         if log.get_level() <= log.DEBUG:
             url = self.__urlstring(api, params, kwargs.get("data", {}))

--- a/sonar/platform.py
+++ b/sonar/platform.py
@@ -113,9 +113,6 @@ class Platform(object):
         """
         return f"{sutil.redacted_token(self.__token)}@{self.local_url}"
 
-    def __credentials(self) -> tuple[str, str]:
-        return self.__token, ""
-
     def verify_connection(self) -> None:
         """Verifies the connection to the SonarQube platform
 
@@ -272,9 +269,9 @@ class Platform(object):
             params = {k: str(v).lower() if isinstance(v, bool) else v for k, v in params.items()}
         elif isinstance(params, (list, tuple)):
             params = [(v[0], str(v[1]).lower() if isinstance(v[1], bool) else v[1]) for v in params]
+        headers["Authorization"] = f"Bearer {self.__token}"
         with_org = kwargs.pop("with_organization", True)
         if self.is_sonarcloud():
-            headers["Authorization"] = f"Bearer {self.__token}"
             if with_org:
                 if isinstance(params, dict):
                     params["organization"] = self.organization
@@ -293,7 +290,6 @@ class Platform(object):
                 start = time.perf_counter_ns()
                 r = request(
                     url=self.local_url + api,
-                    auth=self.__credentials(),
                     verify=self.__verify,
                     params=params,
                     timeout=self.http_timeout,


### PR DESCRIPTION
## Summary
- Use `Authorization: Bearer` header for all platforms (SonarQube Server + Cloud) instead of HTTP Basic Auth for Server
- SonarCloud already used bearer auth via header; now Server does too
- Removed the now-unused `__credentials()` method from Platform class

## Test plan
- [x] Ruff lint passes (no new errors)
- [x] Unit tests pass (12/12 in test_platform.py, excluding pre-existing flaky test_lta_latest)

🤖 Generated with [Claude Code](https://claude.com/claude-code)