### PR TITLE
Upgrade docker image to alpine 3.23.4

### DIFF
--- a/conf/release.Dockerfile
+++ b/conf/release.Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.23.3
+FROM alpine:3.23.4
 LABEL maintainer="olivier.korach@gmail.com" 
 ENV IN_DOCKER="Yes"
 

--- a/conf/snapshot.Dockerfile
+++ b/conf/snapshot.Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.23.3
+FROM alpine:3.23.4
 LABEL maintainer="olivier.korach@gmail.com" 
 ENV IN_DOCKER="Yes"
 

--- a/migration/release.Dockerfile
+++ b/migration/release.Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.23.3
+FROM alpine:3.23.4
 LABEL maintainer="olivier.korach@gmail.com" 
 ENV IN_DOCKER="Yes"
 

--- a/migration/snapshot.Dockerfile
+++ b/migration/snapshot.Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.23.3
+FROM alpine:3.23.4
 LABEL maintainer="olivier.korach@gmail.com" 
 ENV IN_DOCKER="Yes"
 


### PR DESCRIPTION
## Summary
- Bumps alpine base image from 3.23.3 to 3.23.4 in all 4 Dockerfiles

Fixes #2355

## Test plan
- [ ] Verify docker images build successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)