### PR TITLE
Auto-include SCA metrics in sonar-measures-export (Fixes #2370)

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ The following utilities are available:
 - [sonar-housekeeper](https://github.com/okorach/sonar-tools/blob/master/doc/sonar-housekeeper.md): Deletes projects, branches, PR  that have not been analyzed since a certain number of days, or
 deletes tokens created since more than a certain number of days
 - [sonar-loc](https://github.com/okorach/sonar-tools/blob/master/doc/sonar-loc.md): Computes lines of code per project and in total, as they would be computed by SonarQube (and the licensing system on commercial editions)
-- [sonar-measures-export](https://github.com/okorach/sonar-tools/blob/master/doc/sonar-measures-export.md): Exports measures/metrics of one, several or all projects of the instance in CSV
+- [sonar-measures-export](https://github.com/okorach/sonar-tools/blob/master/doc/sonar-measures-export.md): Exports measures/metrics of one, several or all projects of the instance in CSV or JSON. SCA (dependency-risk) metrics are auto-included when the SonarQube Advanced Security add-on is enabled
 - [sonar-findings-export](https://github.com/okorach/sonar-tools/blob/master/doc/sonar-findings-export.md) (Also available as **sonar-issues-export** (deprecated) for backward compatibility): Exports issues, hotspots and SCA dependency risks (potentially filtered) from the instance in CSV, JSON or SARIF
 - [sonar-findings-sync](https://github.com/okorach/sonar-tools/blob/master/doc/sonar-findings-sync.md): Synchronizes issues and hotspots changelog between branches, projects or even SonarQube instances (formerly **sonar-issues-sync**, now deprecated)
 - [sonar-projects](https://github.com/okorach/sonar-tools/blob/master/doc/sonar-projects.md): Exports or imports projects from/to a SonarQube Server instance (EE and higher required for import)

--- a/cli/measures_export.py
+++ b/cli/measures_export.py
@@ -30,7 +30,7 @@ from requests import RequestException
 from sonar.util import types
 from cli import options
 import sonar.logging as log
-from sonar import metrics, platform, exceptions, errcodes, version, measures
+from sonar import metrics, platform, exceptions, errcodes, version, measures, dependency_risks
 import sonar.utilities as sutil
 import sonar.util.misc as util
 import sonar.util.constants as c
@@ -81,7 +81,7 @@ def __get_measures(obj: object, wanted_metrics: types.KeyList, convert_options: 
     return measures_d
 
 
-def __get_wanted_metrics(endpoint: platform.Platform, wanted_metrics: types.KeySet) -> types.KeyList:
+def _get_wanted_metrics(endpoint: platform.Platform, wanted_metrics: types.KeySet) -> types.KeyList:
     """Returns an ordered list of metrics based on CLI inputs"""
     main_metrics = list(metrics.MAIN_METRICS)
     if endpoint.version() >= c.ACCEPT_INTRO_VERSION:
@@ -91,6 +91,8 @@ def __get_wanted_metrics(endpoint: platform.Platform, wanted_metrics: types.KeyS
             main_metrics += metrics.MAIN_METRICS_ENTERPRISE_10
         if endpoint.version() >= (2025, 3, 0):
             main_metrics += metrics.MAIN_METRICS_ENTERPRISE_2025_3
+    if dependency_risks.sca_enabled(endpoint):
+        main_metrics += metrics.sca_metrics(endpoint)
     if "_all" in wanted_metrics or "*" in wanted_metrics:
         all_metrics = list(metrics.Metric.search(endpoint).keys())
         all_metrics.remove("quality_gate_details")
@@ -257,7 +259,7 @@ def main() -> None:
         endpoint.verify_connection()
         endpoint.set_user_agent(f"{TOOL_NAME} {version.PACKAGE_VERSION}")
 
-        wanted_metrics = __get_wanted_metrics(endpoint=endpoint, wanted_metrics=set(kwargs[options.METRIC_KEYS]))
+        wanted_metrics = _get_wanted_metrics(endpoint=endpoint, wanted_metrics=set(kwargs[options.METRIC_KEYS]))
         file = kwargs.pop(options.REPORT_FILE)
         fmt = util.deduct_format(kwargs[options.FORMAT], file)
         kwargs = __check_options_vs_edition(edition=endpoint.edition(), params=kwargs)

--- a/doc/sonar-measures-export.md
+++ b/doc/sonar-measures-export.md
@@ -8,6 +8,7 @@ Basic Usage: `sonar-measures-export -m _main [-f <file>] [--format csv|json] [-b
 - `-m | --metricKeys`: comma separated list of metrics to export
   - `-m _main` is a shortcut to list all main metrics. It's the recommended option
   - `-m _all` is a shortcut to list all metrics, including the most obscure ones
+  - When the SonarQube Advanced Security (SCA) add-on is enabled on the platform, all SCA metrics (`domain: DependencyRisks`, e.g. `sca_count_any_issue`, `sca_rating_vulnerability`, ...) are automatically included in `_main`
 - `-f`: Define file for output (default stdout). File extension is used to deduct expected format (json if file.json, csv otherwise)
 - `--format`: Choose export format between csv (default) and json
 - `-b | --withBranches`: Exports measures for all project branches (by default only export measures of the main branch)
@@ -47,4 +48,12 @@ sonar-measures-export -m _main -b -f measures.json
 
 # Exports all metrics of projects myProjectKey1 and myOtherProjectKey main branch. Convert ratings to letters
 sonar-measures-export -k myProjectKey1,myOtherProjectKey -m _all -r -f all_measures.csv
+
+# On a platform with the SonarQube Advanced Security (SCA) add-on enabled, the default _main export
+# automatically includes the SCA dependency-risk metrics (counts and ratings for vulnerabilities,
+# licenses, malware, security and any-issue, with current and new-code variants)
+sonar-measures-export -m _main -f measures_with_sca.csv
+
+# Limit to specific SCA metrics
+sonar-measures-export -m sca_count_vulnerability,sca_rating_vulnerability,new_sca_count_vulnerability -f sca.csv
 ```

--- a/doc/what-is-new.md
+++ b/doc/what-is-new.md
@@ -1,6 +1,7 @@
 # Next version
 
 * `sonar-findings-export`: Added support for exporting SCA dependency risks via `--types DEPENDENCY_RISK`. Requires the SonarQube Advanced Security add-on (SonarQube Server 2025.4+ Enterprise/Data Center editions, or SonarQube Cloud). Fixes [#2371](https://github.com/okorach/sonar-tools/issues/2371)
+* `sonar-measures-export`: All SCA metrics (domain `DependencyRisks`) are now automatically included in the default `_main` export when the SonarQube Advanced Security add-on is enabled. Fixes [#2370](https://github.com/okorach/sonar-tools/issues/2370). Note: the keys `sca_count_any_issue` and `new_sca_count_any_issue` are no longer included in `_main` on Enterprise / Data Center 2025.3 instances *without* the SCA add-on (those columns were always empty there).
 
 # Version 3.18.3
 

--- a/sonar/metrics.py
+++ b/sonar/metrics.py
@@ -67,7 +67,9 @@ MAIN_METRICS = (
 
 MAIN_METRICS_10 = ("accepted_issues", "software_quality_blocker_issues", "software_quality_high_issues")
 MAIN_METRICS_ENTERPRISE_10 = ("prioritized_rule_issues",)
-MAIN_METRICS_ENTERPRISE_2025_3 = ("contains_ai_code", "sca_count_any_issue", "new_sca_count_any_issue")
+MAIN_METRICS_ENTERPRISE_2025_3 = ("contains_ai_code",)
+
+SCA_METRIC_DOMAIN = "DependencyRisks"
 
 #: Dict of metric grouped by type (INT, FLOAT, WORK_DUR etc...)
 METRICS_BY_TYPE = {}
@@ -149,3 +151,8 @@ class Metric(SqObject):
     def is_an_effort(self) -> bool:
         """Whether a metric is an effort"""
         return self.type == "WORK_DUR"
+
+
+def sca_metrics(endpoint: Platform) -> list[str]:
+    """Returns the metric keys belonging to the SCA (DependencyRisks) domain on the given platform."""
+    return [k for k, m in Metric.search(endpoint, use_cache=True).items() if m.domain == SCA_METRIC_DOMAIN]

--- a/test/unit/test_measures_export.py
+++ b/test/unit/test_measures_export.py
@@ -1,0 +1,126 @@
+#!/usr/bin/env python3
+#
+# sonar-tools tests
+# Copyright (C) 2026 Olivier Korach
+# mailto:olivier.korach AT gmail DOT com
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU Lesser General Public
+# License as published by the Free Software Foundation; either
+# version 3 of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+# Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public License
+# along with this program; if not, write to the Free Software Foundation,
+# Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+
+"""Unit tests for cli.measures_export default-metric-list selection (no live SonarQube required)."""
+
+from unittest.mock import MagicMock, patch
+
+from cli import measures_export
+from sonar import metrics
+
+
+def _mock_endpoint(version=(2025, 4, 0), edition="enterprise") -> MagicMock:
+    endpoint = MagicMock()
+    endpoint.local_url = "http://localhost:9000"
+    endpoint.is_sonarcloud.return_value = False
+    endpoint.version.return_value = version
+    endpoint.edition.return_value = edition
+    return endpoint
+
+
+def _fake_metric(key: str, domain: str) -> MagicMock:
+    m = MagicMock()
+    m.key = key
+    m.domain = domain
+    return m
+
+
+_SCA_KEYS = (
+    "sca_count_any_issue",
+    "sca_count_any_security",
+    "sca_count_licensing",
+    "sca_count_malware",
+    "sca_count_vulnerability",
+    "sca_rating_any_issue",
+    "sca_rating_any_security",
+    "sca_rating_licensing",
+    "sca_rating_malware",
+    "sca_rating_vulnerability",
+    "new_sca_count_any_issue",
+    "new_sca_count_any_security",
+    "new_sca_count_licensing",
+    "new_sca_count_malware",
+    "new_sca_count_vulnerability",
+    "new_sca_rating_any_issue",
+    "new_sca_rating_any_security",
+    "new_sca_rating_licensing",
+    "new_sca_rating_malware",
+    "new_sca_rating_vulnerability",
+)
+
+
+def _platform_metrics() -> dict[str, MagicMock]:
+    """Mimics what Metric.search returns: a mix of regular + SCA metrics."""
+    out = {k: _fake_metric(k, "DependencyRisks") for k in _SCA_KEYS}
+    for k in ("ncloc", "violations", "bugs", "coverage"):
+        out[k] = _fake_metric(k, "Size")
+    out["contains_ai_code"] = _fake_metric("contains_ai_code", "General")
+    out["quality_gate_details"] = _fake_metric("quality_gate_details", "General")
+    return out
+
+
+def test_main_includes_all_sca_metrics_when_sca_enabled() -> None:
+    endpoint = _mock_endpoint()
+    with (
+        patch("cli.measures_export.dependency_risks.sca_enabled", return_value=True),
+        patch("sonar.metrics.Metric.search", return_value=_platform_metrics()),
+    ):
+        wanted = measures_export._get_wanted_metrics(endpoint, {"_main"})
+    for sca_key in _SCA_KEYS:
+        assert sca_key in wanted, f"missing SCA metric {sca_key} in default _main export"
+
+
+def test_main_excludes_sca_metrics_when_sca_disabled() -> None:
+    endpoint = _mock_endpoint()
+    with patch("cli.measures_export.dependency_risks.sca_enabled", return_value=False):
+        wanted = measures_export._get_wanted_metrics(endpoint, {"_main"})
+    assert not any(k.startswith(("sca_", "new_sca_")) for k in wanted)
+
+
+def test_main_excludes_sca_on_old_server_without_sca() -> None:
+    """EE 2025.3 without the SCA add-on must not request sca_* keys."""
+    endpoint = _mock_endpoint(version=(2025, 3, 0), edition="enterprise")
+    with patch("cli.measures_export.dependency_risks.sca_enabled", return_value=False):
+        wanted = measures_export._get_wanted_metrics(endpoint, {"_main"})
+    assert not any(k.startswith(("sca_", "new_sca_")) for k in wanted)
+    assert "contains_ai_code" in wanted  # AI Code Assurance still in default for 2025.3 EE
+
+
+def test_all_mode_with_sca_includes_sca_and_excludes_quality_gate_details() -> None:
+    """With --metricKeys _all, SCA keys are present and quality_gate_details is pruned."""
+    endpoint = _mock_endpoint()
+    with (
+        patch("cli.measures_export.dependency_risks.sca_enabled", return_value=True),
+        patch("sonar.metrics.Metric.search", return_value=_platform_metrics()),
+    ):
+        wanted = measures_export._get_wanted_metrics(endpoint, {"_all"})
+    for sca_key in _SCA_KEYS:
+        assert sca_key in wanted
+    assert "quality_gate_details" not in wanted
+    # Each metric appears exactly once (dedupe via dict.fromkeys at end of helper)
+    assert len(wanted) == len(set(wanted))
+
+
+def test_sca_metrics_helper_filters_by_domain() -> None:
+    endpoint = _mock_endpoint()
+    with patch("sonar.metrics.Metric.search", return_value=_platform_metrics()):
+        result = metrics.sca_metrics(endpoint)
+    assert set(result) == set(_SCA_KEYS)


### PR DESCRIPTION
## Summary
- Discover SCA metrics dynamically by their `domain` (`DependencyRisks`) via `metrics/search` and add them to the default `_main` metric list when `dependency_risks.sca_enabled(endpoint)` returns True.
- Trim two stale SCA keys (`sca_count_any_issue`, `new_sca_count_any_issue`) out of `MAIN_METRICS_ENTERPRISE_2025_3` so they no longer appear as empty columns on EE 2025.3 instances without the SCA add-on.
- Rename `__get_wanted_metrics` to `_get_wanted_metrics` so it can be unit-tested directly.

## Test plan
- [x] `pytest test/unit/test_measures_export.py test/unit/test_dependency_risks.py` (16 passed)
- [x] Broader unit suite still green (54 passed, 1 skipped)
- [x] `ruff check` clean on changed files
- [ ] Live: `sonar-measures-export -m _main -k <project> -f /tmp/out.csv` against an SCA-enabled instance — confirm 20 SCA columns appear
- [ ] Live: same against a non-SCA EE 2025.3 instance — confirm no `sca_*` columns

## Behavior change
Users on EE/DCE 2025.3 *without* the SCA add-on will lose the two `sca_*` columns previously listed in `_main` — those columns were always empty on those instances. Called out in the changelog.

🤖 Generated with [Claude Code](https://claude.com/claude-code)