### PR TITLE
Fix coverage.xml not being generated by run_tests.sh

### DIFF
--- a/conf/run_tests.sh
+++ b/conf/run_tests.sh
@@ -31,6 +31,10 @@ echo "Running tests"
 
 cd "${ROOT_DIR}" || exit 1
 
+# Clear stale coverage data so `coverage xml` at the end doesn't fail
+# on records pointing to test files that have since been removed/renamed.
+poetry run coverage erase
+
 sonar start -i test
 
 testList="${1:-"latest cb 99 cloud"}"


### PR DESCRIPTION
## Summary
- `conf/run_tests.sh` uses `coverage run --append` across multiple targets, so the `.coverage` data file accumulates across runs.
- After `test/unit/test_license_profiles_update.py` was removed (merged into `test_license_profiles.py` in 031a11d5), stale entries in `.coverage` caused the final `coverage xml` step to error out with `No source for code: ...test_license_profiles_update.py` — silently skipping `build/coverage.xml` generation.
- Fix: run `poetry run coverage erase` at the start of the script so each run starts from a clean slate. Side benefit: results from prior runs no longer leak into current totals.

## Test plan
- [ ] Run `conf/run_tests.sh` and confirm `build/coverage.xml` is generated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)