### PR TITLE
Fix new code period DAYS->NUMBER_OF_DAYS (#2385)

### DIFF
--- a/sonar/organizations.py
+++ b/sonar/organizations.py
@@ -135,7 +135,7 @@ class Organization(SqObject):
 
     def new_code_period(self) -> tuple[str, str]:
         if "defaultLeakPeriodType" in self.sq_json and self.sq_json["defaultLeakPeriodType"] == "days":
-            return "DAYS", self.sq_json["defaultLeakPeriod"]
+            return "NUMBER_OF_DAYS", self.sq_json["defaultLeakPeriod"]
         return "PREVIOUS_VERSION", None
 
     def subscription(self) -> str:

--- a/sonar/settings.py
+++ b/sonar/settings.py
@@ -542,6 +542,10 @@ def set_new_code_period(
     endpoint: Platform, nc_type: str, nc_value: Union[int, str], project_key: Optional[str] = None, branch: Optional[str] = None
 ) -> bool:
     """Sets the new code period at global level or for a project"""
+    # The api/new_code_periods/set endpoint expects NUMBER_OF_DAYS; older code paths and
+    # exports pass the legacy alias DAYS. Normalize so both keep working.
+    if nc_type == "DAYS":
+        nc_type = "NUMBER_OF_DAYS"
     log.debug("Setting new code period for project '%s' branch '%s' to value '%s = %s'", str(project_key), str(branch), str(nc_type), str(nc_value))
     if endpoint.is_sonarcloud():
         api, _, params1, _ = endpoint.api.get_details(Setting, Oper.CREATE, key="sonar.leak.period.type", value=nc_type, project=project_key)

--- a/test/unit/test_settings.py
+++ b/test/unit/test_settings.py
@@ -132,9 +132,13 @@ def test_set_visibility() -> None:
 
 def test_set_new_code_period() -> None:
     """test_set_new_code_period"""
-    assert settings.set_new_code_period(tutil.SQ, "DAYS", 42, project_key=tutil.PROJECT_1)
+    assert settings.set_new_code_period(tutil.SQ, "NUMBER_OF_DAYS", 42, project_key=tutil.PROJECT_1)
     o = settings.get_new_code_period(tutil.SQ, component=tutil.PROJECT_1)
-    assert o.value == "DAYS = 42"
+    assert o.value == "NUMBER_OF_DAYS = 42"
+    # Legacy alias DAYS must be normalized to NUMBER_OF_DAYS at the API boundary.
+    assert settings.set_new_code_period(tutil.SQ, "DAYS", 30, project_key=tutil.PROJECT_1)
+    o = settings.get_new_code_period(tutil.SQ, component=tutil.PROJECT_1)
+    assert o.value == "NUMBER_OF_DAYS = 30"
     assert settings.set_new_code_period(tutil.SQ, "SPECIFIC_ANALYSIS", "XXX", project_key=tutil.PROJECT_1)
     assert o.value == "SPECIFIC_ANALYSIS = XXX"
     assert o.reset()


### PR DESCRIPTION
## Summary
- Closes #2385.
- The SonarQube API `api/new_code_periods/set` expects `type=NUMBER_OF_DAYS`, not the legacy alias `DAYS`. Sending `DAYS` made the call fail.
- `set_new_code_period` now normalizes `DAYS` → `NUMBER_OF_DAYS` at the API boundary, so legacy callers (and old config exports) keep working transparently.
- `Organization.new_code_period()` now returns `NUMBER_OF_DAYS` so future exports use the correct token.

## Test plan
- [x] `test_set_new_code_period` updated to assert `NUMBER_OF_DAYS = 42` and to add an explicit regression case that the legacy `DAYS` alias still works (gets normalized).
- [ ] Existing org export/import tests continue to pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)