### PR TITLE
Fix release.sh grep to match Dockerfile pip install pattern

### DIFF
--- a/conf/release.sh
+++ b/conf/release.sh
@@ -25,7 +25,7 @@ CONF_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 
 DOCKERFILE_RELEASE="${CONF_DIR}/release.Dockerfile"
 
-docker_VERSION=$(grep 'pip install sonar-tools==' "${DOCKERFILE_RELEASE}" | sed -E 's/.*sonar-tools==([0-9\.]+).*/\1/')
+docker_VERSION=$(grep -E 'pip install .* sonar-tools==' "${DOCKERFILE_RELEASE}" | sed -E 's/.*sonar-tools==([0-9\.]+).*/\1/')
 
 if [[ "${VERSION}" != "${docker_VERSION}" ]]; then
     echo "Docker VERSION and pypi VERSION are different (${docker_VERSION} vs ${VERSION}), release aborted"


### PR DESCRIPTION
## Summary
- Update grep pattern in `conf/release.sh` to use `-E` and match `pip install .* sonar-tools==` so it tolerates additional flags between `install` and the package name in `release.Dockerfile`.

## Test plan
- [ ] Run `conf/release.sh` against a `release.Dockerfile` whose pip install line contains extra flags and confirm `docker_VERSION` is extracted correctly.
- [ ] Confirm version mismatch detection still aborts the release as expected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)