### PR TITLE
Bump version to 3.21

### DIFF
--- a/conf/release.Dockerfile
+++ b/conf/release.Dockerfile
@@ -28,7 +28,7 @@ COPY ./LICENSE .
 COPY ./sonar/audit sonar/audit
 
 RUN pip install --upgrade pip \
-&& pip install sonar-tools==3.20
+&& pip install sonar-tools==3.21
 
 USER ${USERNAME}
 WORKDIR /home/${USERNAME}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "sonar-tools"
-version = "3.20"
+version = "3.21"
 description = "A collection of utility tools for the SonarQube ecosystem"
 authors = [
   {name = "Olivier Korach", email = "olivier.korach@gmail.com"},

--- a/sonar/version.py
+++ b/sonar/version.py
@@ -20,5 +20,5 @@
 
 """sonar-tools project version"""
 
-PACKAGE_VERSION = "3.20"
+PACKAGE_VERSION = "3.21"
 MIGRATION_TOOL_VERSION = "0.7"


### PR DESCRIPTION
## Summary
- Bump package version from 3.20 to 3.21 in `pyproject.toml` and `sonar/version.py`
- Bump pinned `sonar-tools` version in `conf/release.Dockerfile` to 3.21

## Test plan
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)