### PR TITLE
Tech debt: encapsulate private attributes behind @property, tighter types and cleanup

### DIFF
--- a/cli/findings_export.py
+++ b/cli/findings_export.py
@@ -449,8 +449,8 @@ def main() -> None:
             if not dependency_risks.sca_enabled(sqenv):
                 chelp.clear_cache_and_exit(
                     errcodes.UNSUPPORTED_OPERATION,
-                    f"--{options.TYPES} {idefs.TYPE_DEPENDENCY_RISK} " +
-                    "requires the SonarQube Advanced Security add-on, which is not enabled on this platform",
+                    f"--{options.TYPES} {idefs.TYPE_DEPENDENCY_RISK} "
+                    + "requires the SonarQube Advanced Security add-on, which is not enabled on this platform",
                 )
             if params[options.COMPONENT_TYPE] == "applications":
                 components_list = _expand_applications_to_components(components_list)

--- a/cli/findings_export.py
+++ b/cli/findings_export.py
@@ -53,6 +53,7 @@ from sonar.issues import TooManyFacetsError
 
 if TYPE_CHECKING:
     from sonar.projects import Project
+    from sonar.components import Component
     from sonar.branches import Branch
     from sonar.pull_requests import PullRequest
     from sonar.issues import Issue
@@ -359,7 +360,7 @@ def store_findings(components_list: list[object], endpoint: platform.Platform, p
     return total_findings
 
 
-def _expand_applications_to_components(applications_list: list) -> list:
+def _expand_applications_to_components(applications_list: list[Component]) -> list[Union[Project, Branch]]:
     """Expands a list of Application objects into the underlying Project / Branch components.
 
     SCA dependency risks are only queryable per-project, so applications are flattened to their
@@ -448,7 +449,8 @@ def main() -> None:
             if not dependency_risks.sca_enabled(sqenv):
                 chelp.clear_cache_and_exit(
                     errcodes.UNSUPPORTED_OPERATION,
-                    f"--{options.TYPES} {idefs.TYPE_DEPENDENCY_RISK} requires the SonarQube Advanced Security add-on, which is not enabled on this platform",
+                    f"--{options.TYPES} {idefs.TYPE_DEPENDENCY_RISK} " +
+                    "requires the SonarQube Advanced Security add-on, which is not enabled on this platform",
                 )
             if params[options.COMPONENT_TYPE] == "applications":
                 components_list = _expand_applications_to_components(components_list)

--- a/cli/projects_cli.py
+++ b/cli/projects_cli.py
@@ -77,7 +77,7 @@ def __import_projects(endpoint: Platform, **kwargs: Any) -> None:
         with open(file, encoding="utf-8") as fd:
             data = json.load(fd)
     except json.JSONDecodeError as e:
-        raise options.ArgumentsError(f"JSON decoding error while reading file '{file}': {e!s}")
+        raise options.ArgumentsError(f"JSON decoding error while reading file '{file}': {e!s}") from e
 
     if "projects" in data:
         # 3.13 and higher format

--- a/sonar/app_branches.py
+++ b/sonar/app_branches.py
@@ -158,6 +158,7 @@ class ApplicationBranch(Component):
 
         return Hotspot.search(self.endpoint, **(search_params | {"project": self.concerned_object.key, "branch": self.name}))
 
+    @property
     def is_main(self) -> bool:
         """Returns whether app branch is main"""
         return self._is_main
@@ -180,7 +181,7 @@ class ApplicationBranch(Component):
         :return: Whether the delete succeeded
         :rtype: bool
         """
-        if self.is_main():
+        if self.is_main:
             log.warning("Can't delete main application branch, simply delete the application for that", self)
             return False
         log.info("Deleting %s", self)
@@ -194,7 +195,7 @@ class ApplicationBranch(Component):
         """
         log.info("Exporting %s from %s", self, self.sq_json)
         jsondata = {"projects": {b["key"]: b["branch"] if b["selected"] else sutil.DEFAULT for b in self.sq_json["projects"]}}
-        if self.is_main():
+        if self.is_main:
             jsondata["isMain"] = True
         return jsondata
 

--- a/sonar/applications.py
+++ b/sonar/applications.py
@@ -181,11 +181,11 @@ class Application(aggr.Aggregation):
         """:return: Whether the Application branch is the main branch
         :rtype: bool
         """
-        return app_branches.ApplicationBranch.get_object(self.endpoint, self, branch).is_main()
+        return app_branches.ApplicationBranch.get_object(self.endpoint, self, branch).is_main
 
     def main_branch(self) -> object:
         """Returns the application main branch"""
-        return next((br for br in self.branches().values() if br.is_main()), None)
+        return next((br for br in self.branches().values() if br.is_main), None)
 
     def create_branch(self, branch_name: str, branch_definition: ObjectJsonRepr) -> object:
         """Creates an application branch
@@ -253,7 +253,7 @@ class Application(aggr.Aggregation):
 
         :return: Whether the delete succeeded
         """
-        for branch in [b for b in self.branches().values() if not b.is_main()]:
+        for branch in [b for b in self.branches().values() if not b.is_main]:
             branch.delete()
         return self.delete_object(application=self.key)
 

--- a/sonar/branches.py
+++ b/sonar/branches.py
@@ -152,17 +152,27 @@ class Branch(components.Component):
         """Returns the project key"""
         return self.concerned_object
 
+    @property
     def is_kept_when_inactive(self) -> bool:
         """Returns whether the branch is kept when inactive"""
         if self._keep_when_inactive is None or self.sq_json is None:
             self.refresh()
         return self._keep_when_inactive
 
+    @is_kept_when_inactive.setter
+    def is_kept_when_inactive(self, value: Optional[bool]) -> None:
+        self._keep_when_inactive = value
+
+    @property
     def is_main(self) -> bool:
         """Returns whether the branch is the project main branch"""
         if self._is_main is None or self.sq_json is None:
             self.refresh()
         return self._is_main
+
+    @is_main.setter
+    def is_main(self, value: Optional[bool]) -> None:
+        self._is_main = value
 
     def delete(self) -> bool:
         """Deletes a branch, return whether the deletion was successful"""
@@ -213,7 +223,7 @@ class Branch(components.Component):
         :return: Whether the operation was successful
         """
         log.info("Setting %s keep when inactive to %s", self, keep)
-        if self.is_main():
+        if self.is_main:
             if not keep:
                 log.warning("%s is main branch, can't be purgeable, skipping...", str(self))
                 raise exceptions.UnsupportedOperation(f"{self!s} is the main branch, can't be purgeable")
@@ -232,7 +242,7 @@ class Branch(components.Component):
         :raises UnsupportedOperation: If trying to rename anything than the main branch
         :return: Whether the operation was successful
         """
-        if not self.is_main():
+        if not self.is_main:
             raise exceptions.UnsupportedOperation(f"{self!s} can't be renamed since it's not the main branch")
 
         log.info("Renaming main branch of %s from '%s' to '%s'", str(self.concerned_object), self.name, new_name)
@@ -252,7 +262,7 @@ class Branch(components.Component):
         api, _, params, _ = self.endpoint.api.get_details(self, Oper.SET_MAIN, project=self.concerned_object.key, branch=self.name)
         self.post(api, params=params)
         for b in self.concerned_object.branches().values():
-            b._is_main = b.name == self.name
+            b.is_main = b.name == self.name
         return True
 
     def set_new_code(self, new_code_type: str, additional_data: Optional[Any]) -> bool:
@@ -275,9 +285,9 @@ class Branch(components.Component):
         """
         log.debug("Exporting %s", str(self))
         data = {settings.NEW_CODE_PERIOD: self.new_code()}
-        if self.is_main():
+        if self.is_main:
             data["isMain"] = True
-        if self.is_kept_when_inactive() and not self.is_main():
+        if self.is_kept_when_inactive and not self.is_main:
             data["keepWhenInactive"] = True
         if self.new_code():
             data[settings.NEW_CODE_PERIOD] = self.new_code()
@@ -358,12 +368,12 @@ class Branch(components.Component):
 
     def __audit_never_analyzed(self) -> list[Problem]:
         """Detects branches that have never been analyzed are are kept when inactive"""
-        if not self.last_analysis() and self.is_kept_when_inactive():
+        if not self.last_analysis() and self.is_kept_when_inactive:
             return [Problem(get_rule(RuleId.BRANCH_NEVER_ANALYZED), self, str(self))]
         return []
 
     def __audit_last_analysis(self, audit_settings: ConfigSettings) -> list[Problem]:
-        if self.is_main():
+        if self.is_main:
             log.info("%s is main (not purgeable)", str(self))
             return []
         if (max_age := audit_settings.get("audit.projects.branches.maxLastAnalysisAge", 30)) == 0:
@@ -377,7 +387,7 @@ class Branch(components.Component):
         if preserved is not None and age > max_age and not re.match(rf"^{preserved}$", self.name):
             log.info("%s age %d greater than %d days and not matches '%s'", str(self), age, max_age, preserved)
             problems.append(Problem(get_rule(RuleId.BRANCH_LAST_ANALYSIS), self, str(self), age))
-        elif self.is_kept_when_inactive():
+        elif self.is_kept_when_inactive:
             log.info("%s is kept when inactive (not purgeable)", str(self))
         elif age > max_age:
             problems.append(Problem(get_rule(RuleId.BRANCH_LAST_ANALYSIS), self, str(self), age))

--- a/sonar/branches.py
+++ b/sonar/branches.py
@@ -46,6 +46,7 @@ from sonar import measures
 if TYPE_CHECKING:
     from sonar.tasks import Task
     from sonar.issues import Issue
+    from sonar.dependency_risks import DependencyRisk
     from sonar.hotspots import Hotspot
     from sonar.platform import Platform
     from sonar.components import Component
@@ -322,7 +323,7 @@ class Branch(components.Component):
         """Returns a list of findings, issues and hotspots together on a branch"""
         return self.concerned_object.get_findings(**(search_params | {"branch": self.name}))
 
-    def get_dependency_risks(self, **search_params: Any) -> dict:
+    def get_dependency_risks(self, **search_params: Any) -> dict[str, DependencyRisk]:
         """Returns the SCA dependency risks for this branch"""
         from sonar.dependency_risks import DependencyRisk
 

--- a/sonar/components.py
+++ b/sonar/components.py
@@ -42,6 +42,7 @@ if TYPE_CHECKING:
     from sonar.platform import Platform
     from sonar.hotspots import Hotspot
     from sonar.issues import Issue
+    from sonar.dependency_risks import DependencyRisk
     from sonar.util.types import ApiPayload, ConfigSettings, KeyList
 
 
@@ -105,7 +106,7 @@ class Component(SqObject):
         new_params = {k: v for k, v in search_params.items() if k not in ("project", "application", "portfolio")}
         return Hotspot.search(endpoint=self.endpoint, **(new_params | {"project": self.key}))
 
-    def get_dependency_risks(self, **search_params: Any) -> dict:
+    def get_dependency_risks(self, **search_params: Any) -> dict[str, DependencyRisk]:
         """Returns list of SCA dependency risks for a project component"""
         from sonar.dependency_risks import DependencyRisk
 
@@ -274,7 +275,7 @@ class Component(SqObject):
         except (ConnectionError, RequestException) as e:
             sutil.handle_error(e, f"getting AI code assurance of {self}", catch_all=True)
             if "Unknown url" in sutil.error_msg(e):
-                raise exceptions.UnsupportedOperation(f"AI code assurance is not available for {self.endpoint.edition()} edition version {version!s}")
+                raise exceptions.UnsupportedOperation(f"AI code assurance is not available for {self.endpoint.edition()} edition version {version!s}") from e
         return None
 
     def _audit_bg_task(self, audit_settings: ConfigSettings) -> list[Problem]:

--- a/sonar/components.py
+++ b/sonar/components.py
@@ -275,7 +275,9 @@ class Component(SqObject):
         except (ConnectionError, RequestException) as e:
             sutil.handle_error(e, f"getting AI code assurance of {self}", catch_all=True)
             if "Unknown url" in sutil.error_msg(e):
-                raise exceptions.UnsupportedOperation(f"AI code assurance is not available for {self.endpoint.edition()} edition version {version!s}") from e
+                raise exceptions.UnsupportedOperation(
+                    f"AI code assurance is not available for {self.endpoint.edition()} edition version {version!s}"
+                ) from e
         return None
 
     def _audit_bg_task(self, audit_settings: ConfigSettings) -> list[Problem]:

--- a/sonar/dependency_risks.py
+++ b/sonar/dependency_risks.py
@@ -199,7 +199,8 @@ class DependencyRisk(SqObject):
         return f"{self.vulnerability_id or 'Vulnerability'} in {pkg} {version}"
 
     def __str__(self) -> str:
-        return f"dependency risk '{self.key}' ({self.type})"
+        """Returns a human-readable representation of the risk."""
+        return f"{self._compute_headline()} for {str(self.project_key)}{f' branch {self.branch}' if self.branch else ''}{f' PR {self.pull_request}' if self.pull_request else ''}"
 
     def url(self) -> str:
         """Returns the permalink to the dependency risk in the SonarQube UI."""
@@ -386,7 +387,7 @@ class DependencyRisk(SqObject):
             self._comments = None
             return True
 
-    def get_tags(self) -> list[str]:
+    def get_tags(self, **kwargs: Any) -> list[str]:
         """Returns tags - not applicable for dependency risks."""
         raise exceptions.UnsupportedOperation("DependencyRisk does not support tags")
 

--- a/sonar/dependency_risks.py
+++ b/sonar/dependency_risks.py
@@ -552,10 +552,7 @@ class DependencyRisk(SqObject):
         counter = 0
         self._sync_source_url = source.url()
         last_target_change = self.last_changelog_date()
-        events = {
-            k: v for k, v in source.changelog.items()
-            if last_target_change is None or v.date_time() > last_target_change
-        }
+        events = {k: v for k, v in source.changelog.items() if last_target_change is None or v.date_time() > last_target_change}
         if len(events) == 0:
             log.info("Source %s has no changelog after target %s last change (%s)", source, self, last_target_change)
         else:
@@ -565,10 +562,7 @@ class DependencyRisk(SqObject):
                 counter += 1
 
         last_target_comment = self.last_comment_date()
-        comment_events = {
-            k: v for k, v in source.comments.items()
-            if last_target_comment is None or (v["date"] and v["date"] > last_target_comment)
-        }
+        comment_events = {k: v for k, v in source.comments.items() if last_target_comment is None or (v["date"] and v["date"] > last_target_comment)}
         if len(comment_events) == 0:
             log.info("Source %s has no comments after target %s last comment (%s)", source, self, last_target_comment)
         else:

--- a/sonar/dependency_risks.py
+++ b/sonar/dependency_risks.py
@@ -333,12 +333,20 @@ class DependencyRisk(SqObject):
             self._load_changelog_and_comments()
         return self._changelog
 
+    @changelog.setter
+    def changelog(self, value: Optional[dict[str, DependencyRiskChangelog]]) -> None:
+        self._changelog = value
+
     @property
     def comments(self) -> dict[str, dict[str, Any]]:
         """Lazy-loaded comments extracted from the changelog. Callers needing a date filter apply it themselves."""
         if self._comments is None:
             self._load_changelog_and_comments()
         return self._comments
+
+    @comments.setter
+    def comments(self, value: Optional[dict[str, dict[str, Any]]]) -> None:
+        self._comments = value
 
     def _load_changelog_and_comments(self) -> None:
         """Loads both changelog and comments from the API in a single call."""

--- a/sonar/dependency_risks.py
+++ b/sonar/dependency_risks.py
@@ -326,20 +326,18 @@ class DependencyRisk(SqObject):
     # Sync-related API: changelog, comments, transitions, assignment
     # ---------------------------------------------------------------------
 
-    def changelog(self, after: Optional[datetime] = None) -> dict[str, DependencyRiskChangelog]:
-        """Returns the changelog of a dependency risk, optionally filtered to entries after a date."""
+    @property
+    def changelog(self) -> dict[str, DependencyRiskChangelog]:
+        """Lazy-loaded changelog of the dependency risk. Callers needing a date filter apply it themselves."""
         if self._changelog is None:
             self._load_changelog_and_comments()
-        if after is not None:
-            return {k: v for k, v in self._changelog.items() if v.date_time() > after}
         return self._changelog
 
-    def comments(self, after: Optional[datetime] = None) -> dict[str, dict[str, Any]]:
-        """Returns comments extracted from the changelog."""
+    @property
+    def comments(self) -> dict[str, dict[str, Any]]:
+        """Lazy-loaded comments extracted from the changelog. Callers needing a date filter apply it themselves."""
         if self._comments is None:
             self._load_changelog_and_comments()
-        if after is not None:
-            return {k: v for k, v in self._comments.items() if v["date"] and v["date"] > after}
         return self._comments
 
     def _load_changelog_and_comments(self) -> None:
@@ -401,29 +399,29 @@ class DependencyRisk(SqObject):
 
     def has_changelog(self, after: Optional[datetime] = None, manual_only: Optional[bool] = True) -> bool:  # noqa: ARG002
         """Returns whether the dependency risk has a changelog"""
-        return len(self.changelog(after=after)) > 0
+        return any(after is None or v.date_time() > after for v in self.changelog.values())
 
     def has_comments(self, after: Optional[datetime] = None) -> bool:
         """Returns whether the dependency risk has comments"""
-        return len(self.comments(after=after)) > 0
+        return any(after is None or (v["date"] and v["date"] > after) for v in self.comments.values())
 
     def last_changelog_date(self) -> Optional[datetime]:
         """Returns the date of the last changelog entry"""
-        ch = self.changelog()
+        ch = self.changelog
         return list(ch.values())[-1].date_time() if len(ch) > 0 else None
 
     def last_comment_date(self) -> Optional[datetime]:
         """Returns the date of the last comment"""
-        ch = self.comments()
+        ch = self.comments
         return list(ch.values())[-1]["date"] if len(ch) > 0 else None
 
     def modifiers(self, after: Optional[datetime] = None) -> set[str]:
         """Returns the set of users that modified the dependency risk"""
-        return {c.author() for c in self.changelog(after=after).values() if c.author()}
+        return {c.author() for c in self.changelog.values() if c.author() and (after is None or c.date_time() > after)}
 
     def commenters(self) -> set[str]:
         """Returns the set of users that commented on the dependency risk"""
-        return {v["user"] for v in self.comments().values() if v.get("user")}
+        return {v["user"] for v in self.comments.values() if v.get("user")}
 
     def strictly_identical_to(self, other: DependencyRisk, ignore_component: bool = False) -> bool:  # noqa: ARG002
         """Two dependency risks are identical if they share the same identity fields.
@@ -546,7 +544,10 @@ class DependencyRisk(SqObject):
         counter = 0
         self._sync_source_url = source.url()
         last_target_change = self.last_changelog_date()
-        events = source.changelog(after=last_target_change)
+        events = {
+            k: v for k, v in source.changelog.items()
+            if last_target_change is None or v.date_time() > last_target_change
+        }
         if len(events) == 0:
             log.info("Source %s has no changelog after target %s last change (%s)", source, self, last_target_change)
         else:
@@ -556,7 +557,10 @@ class DependencyRisk(SqObject):
                 counter += 1
 
         last_target_comment = self.last_comment_date()
-        comment_events = source.comments(after=last_target_comment)
+        comment_events = {
+            k: v for k, v in source.comments.items()
+            if last_target_comment is None or (v["date"] and v["date"] > last_target_comment)
+        }
         if len(comment_events) == 0:
             log.info("Source %s has no comments after target %s last comment (%s)", source, self, last_target_comment)
         else:

--- a/sonar/devops.py
+++ b/sonar/devops.py
@@ -71,6 +71,11 @@ class DevopsPlatform(SqObject):
             string += f" workspace '{self._specific['workspace']}'"
         return string
 
+    @property
+    def specific(self) -> Optional[dict[str, str]]:
+        """Returns the DevOps platform-specific settings."""
+        return self._specific
+
     @classmethod
     def get_object(cls, endpoint: Platform, key: str, use_cache: bool = True) -> DevopsPlatform:
         """Reads a devops platform object in Sonar instance"""

--- a/sonar/issues.py
+++ b/sonar/issues.py
@@ -585,6 +585,13 @@ class Issue(findings.Finding):
         else:
             return self.__set_severity(impact=f"{software_quality}={severity}")
 
+    @property
+    def tags(self) -> Optional[list[str]]:
+        """Returns the cached tags of an issue without forcing a refresh."""
+        if self._tags is None:
+            self._tags = self.sq_json.get("tags")
+        return self._tags
+
     def get_tags(self, **kwargs: Any) -> list[str]:
         """Returns the tags of an issue"""
         use_cache = kwargs.get(c.USE_CACHE, True)
@@ -1048,6 +1055,6 @@ def post_search_filter(issue_list: dict[str, Issue], **search_params: Any) -> di
     if "languages" in params:
         issue_list = {k: i for k, i in issue_list.items() if i.language() in params["languages"]}
     if "tags" in params:
-        issue_list = {k: i for k, i in issue_list.items() if i.tags and all(t in i._tags for t in params["tags"])}
+        issue_list = {k: i for k, i in issue_list.items() if i.tags and all(t in i.tags for t in params["tags"])}
     log.debug("Post-search filters %s returns %d issues", search_params, len(issue_list))
     return issue_list

--- a/sonar/platform.py
+++ b/sonar/platform.py
@@ -162,7 +162,7 @@ class Platform(object):
         """Returns the SonarQube edition: 'community', 'developer', 'enterprise', 'datacenter' or 'sonarcloud'"""
         if self.is_sonarcloud():
             return c.SC
-        return sutil.edition_normalize(self.global_nav().get("edition") or self.sys_info()["Statistics"]["edition"])
+        return sutil.edition_normalize(self.global_nav().get("edition") or self.sys_info["Statistics"]["edition"])
 
     def user(self) -> str:
         """Returns the user corresponding to the provided token"""
@@ -369,6 +369,7 @@ class Platform(object):
             self._permissions = global_permissions.GlobalPermissions(self)
         return self._permissions
 
+    @property
     def sys_info(self) -> dict[str, Any]:
         """Returns the SonarQube platform system info JSON"""
         MAX_RETRIES = 10
@@ -393,6 +394,10 @@ class Platform(object):
             success = True
         return self._sys_info
 
+    @sys_info.setter
+    def sys_info(self, value: Optional[dict[str, Any]]) -> None:
+        self._sys_info = value
+
     def global_nav(self) -> dict[str, Any]:
         """Returns the SonarQube platform global navigation data"""
         if self.__global_nav is None:
@@ -404,13 +409,13 @@ class Platform(object):
         """Returns the SonarQube platform backend database"""
         if self.is_sonarcloud():
             return "postgresql"
-        return self.sys_info()["Database"]["Database"]
+        return self.sys_info["Database"]["Database"]
 
     def plugins(self) -> dict[str, dict[str, str]]:
         """Returns the SonarQube platform plugins data"""
         if self.is_sonarcloud():
             return {}
-        sysinfo = self.sys_info()
+        sysinfo = self.sys_info
         if "Application Nodes" in sysinfo:
             sysinfo = sysinfo["Application Nodes"][0]
         try:
@@ -606,7 +611,7 @@ class Platform(object):
         if self.is_sonarcloud():
             return problems
 
-        pf_sif = self.sys_info() | {"edition": self.edition()}
+        pf_sif = self.sys_info | {"edition": self.edition()}
         problems += (
             _audit_maintainability_rating_grid(platform_settings, audit_settings, settings_url)
             + self._audit_admin_password()

--- a/sonar/platform.py
+++ b/sonar/platform.py
@@ -394,9 +394,7 @@ class Platform(object):
         return self._sys_info
 
     def global_nav(self) -> dict[str, Any]:
-        """
-        :return: the SonarQube platform global navigation data
-        """
+        """Returns the SonarQube platform global navigation data"""
         if self.__global_nav is None:
             resp = self.get("navigation/global", mute=(HTTPStatus.INTERNAL_SERVER_ERROR,))
             self.__global_nav = json.loads(resp.text)

--- a/sonar/portfolios.py
+++ b/sonar/portfolios.py
@@ -249,7 +249,7 @@ class Portfolio(aggregations.Aggregation):
         for app_data in apps:
             app_o = applications.Application.get_object(self.endpoint, app_data["originalKey"])
             for branch in app_data["selectedBranches"]:
-                if app_branches.ApplicationBranch.get_object(self.endpoint, app=app_o, branch_name=branch).is_main():
+                if app_branches.ApplicationBranch.get_object(self.endpoint, app=app_o, branch_name=branch).is_main:
                     app_data["selectedBranches"].remove(branch)
                     app_data["selectedBranches"].insert(0, c.DEFAULT_BRANCH)
             self._applications[app_data["originalKey"]] = app_data["selectedBranches"]
@@ -362,7 +362,7 @@ class Portfolio(aggregations.Aggregation):
                 subp_json = s.to_json(export_settings)
                 subp_key = subp_json.pop("key")
                 json_data["portfolios"][subp_key] = subp_json
-        mode = self.selection_mode().copy()
+        mode = self.selection_mode.copy()
         if mode:
             if "none" not in mode or export_settings.get("MODE", "") == "MIGRATION":
                 json_data["projects"] = mode
@@ -392,6 +392,7 @@ class Portfolio(aggregations.Aggregation):
             # No permissions for SVW
             self.permissions().set(portfolio_perms)
 
+    @property
     def selection_mode(self) -> dict[str, str]:
         """Returns a portfolio selection mode"""
         if self._selection_mode is None:
@@ -399,6 +400,15 @@ class Portfolio(aggregations.Aggregation):
             api, _, params, _ = self.endpoint.api.get_details(self, Oper.GET, key=self.root_portfolio.key)
             self.reload(json.loads(self.get(api, params=params).text))
         return {k.lower(): v for k, v in self._selection_mode.items()}
+
+    @selection_mode.setter
+    def selection_mode(self, value: Optional[dict[str, Any]]) -> None:
+        self._selection_mode = value
+
+    @property
+    def description(self) -> Optional[str]:
+        """Returns the portfolio description"""
+        return self._description
 
     def has_project(self, key: str) -> bool:
         return _SELECTION_MODE_MANUAL in self._selection_mode and key in self._selection_mode[_SELECTION_MODE_MANUAL]

--- a/sonar/portfolios.py
+++ b/sonar/portfolios.py
@@ -186,7 +186,7 @@ class Portfolio(aggregations.Aggregation):
             return
         branch = self.sq_json.get("branch", c.DEFAULT_BRANCH)
         if mode == _SELECTION_MODE_MANUAL:
-            self._selection_mode = {mode: {}}
+            self.selection_mode = {mode: {}}
             if not (sprojects := self.sq_json.get("selectedProjects")):
                 return
             selected_projects = dict(sorted(util.list_to_dict(sprojects, "projectKey", keep_in_values=True).items()))
@@ -194,13 +194,13 @@ class Portfolio(aggregations.Aggregation):
                 branch_list = projdata.get("selectedBranches", [c.DEFAULT_BRANCH])
                 self._selection_mode[mode].update({projdata["projectKey"]: set(branch_list)})
         elif mode == _SELECTION_MODE_REGEXP:
-            self._selection_mode = {mode: self.sq_json["regexp"], "branch": branch}
+            self.selection_mode = {mode: self.sq_json["regexp"], "branch": branch}
         elif mode == _SELECTION_MODE_TAGS:
-            self._selection_mode = {mode: self.sq_json["tags"], "branch": branch}
+            self.selection_mode = {mode: self.sq_json["tags"], "branch": branch}
         elif mode == _SELECTION_MODE_REST:
-            self._selection_mode = {mode: True, "branch": branch}
+            self.selection_mode = {mode: True, "branch": branch}
         else:
-            self._selection_mode = {mode: True}
+            self.selection_mode = {mode: True}
 
     def refresh(self) -> Portfolio:
         """Refreshes a portfolio data from the Sonar instance"""
@@ -222,12 +222,12 @@ class Portfolio(aggregations.Aggregation):
 
     def projects(self) -> Optional[dict[str, str]]:
         """Returns list of projects and their branches if selection mode is manual, or the list of projects for other modes"""
-        if not self._selection_mode or _SELECTION_MODE_MANUAL not in self._selection_mode:
+        if not self.selection_mode or _SELECTION_MODE_MANUAL not in self.selection_mode:
             if self._projects is None:
                 data = json.loads(self.get("api/views/projects_status", params={"portfolio": self.key}).text)
                 self._projects = {p["refKey"]: {c.DEFAULT_BRANCH} for p in data["projects"]}
             return self._projects
-        return self._selection_mode[_SELECTION_MODE_MANUAL]
+        return self.selection_mode[_SELECTION_MODE_MANUAL]
 
     def components(self) -> list[Union[Project, Branch]]:
         """Returns the list of components objects (projects/branches) in the portfolio"""
@@ -450,34 +450,34 @@ class Portfolio(aggregations.Aggregation):
         """Sets a portfolio to manual mode"""
         if not self._selection_mode or _SELECTION_MODE_MANUAL not in self._selection_mode:
             self.post("views/set_manual_mode", params={"portfolio": self.key})
-            self._selection_mode = {_SELECTION_MODE_MANUAL: {}}
+            self.selection_mode = {_SELECTION_MODE_MANUAL: {}}
         return self
 
     def set_tags_mode(self, tags: list[str], branch: Optional[str] = None) -> Portfolio:
         """Sets a portfolio to tags mode"""
         self.post("views/set_tags_mode", params={"portfolio": self.key, "tags": util.list_to_csv(tags), "branch": branch})
-        self._selection_mode = {_SELECTION_MODE_TAGS: tags, "branch": branch or c.DEFAULT_BRANCH}
+        self.selection_mode = {_SELECTION_MODE_TAGS: tags, "branch": branch or c.DEFAULT_BRANCH}
         return self
 
     def set_regexp_mode(self, regexp: str, branch: Optional[str] = None) -> Portfolio:
         """Sets a portfolio to regexp mode"""
         self.post("views/set_regexp_mode", params={"portfolio": self.key, "regexp": regexp, "branch": branch})
-        self._selection_mode = {_SELECTION_MODE_REGEXP: regexp, "branch": branch or c.DEFAULT_BRANCH}
+        self.selection_mode = {_SELECTION_MODE_REGEXP: regexp, "branch": branch or c.DEFAULT_BRANCH}
         return self
 
     def set_remaining_projects_mode(self, branch: Optional[str] = None) -> Portfolio:
         """Sets a portfolio to remaining projects mode"""
         self.post("views/set_remaining_projects_mode", params={"portfolio": self.key, "branch": branch})
-        self._selection_mode = {"rest": True, "branch": branch or c.DEFAULT_BRANCH}
+        self.selection_mode = {"rest": True, "branch": branch or c.DEFAULT_BRANCH}
         return self
 
     def set_none_mode(self) -> Portfolio:
         """Sets a portfolio to none mode"""
         # Hack: API change between 9.0 and 9.1
-        mode = self._selection_mode
+        mode = self.selection_mode
         if not mode or len(mode) > 0:
             self.post("views/set_none_mode", params={"portfolio": self.key})
-            self._selection_mode = {}
+            self.selection_mode = {}
         return self
 
     def set_selection_mode(self, data: dict[str, Any]) -> Portfolio:

--- a/sonar/projects.py
+++ b/sonar/projects.py
@@ -251,7 +251,7 @@ class Project(Component):
         if self.endpoint.edition() == c.CE:
             raise exceptions.UnsupportedOperation("Main branch is not supported in Community Edition")
         try:
-            return next(b for b in self.branches().values() if b.is_main())
+            return next(b for b in self.branches().values() if b.is_main)
         except StopIteration:
             log.warning("Could not find main branch for %s", str(self))
         return None

--- a/sonar/pull_requests.py
+++ b/sonar/pull_requests.py
@@ -40,6 +40,7 @@ from sonar import measures
 if TYPE_CHECKING:
     from sonar.issues import Issue
     from sonar.hotspots import Hotspot
+    from sonar.dependency_risks import DependencyRisk
     from sonar.util.types import ApiPayload, ConfigSettings
     from sonar.platform import Platform
 
@@ -185,7 +186,7 @@ class PullRequest(Component):
         """Returns a list of findings, issues and hotspots together on a PR"""
         return self.concerned_object.get_findings(**(search_params | {"pullRequest": self.key}))
 
-    def get_dependency_risks(self, **search_params: Any) -> dict:
+    def get_dependency_risks(self, **search_params: Any) -> dict[str, DependencyRisk]:
         """Returns the SCA dependency risks for this pull request"""
         from sonar.dependency_risks import DependencyRisk
 

--- a/sonar/qualitygates.py
+++ b/sonar/qualitygates.py
@@ -254,9 +254,9 @@ class QualityGate(SqObject):
             data = json.loads(self.get(api, params=params).text)
             log.debug("Loading %s with conditions %s", self, util.json_dump(data))
             self._conditions = list(data.get("conditions", []))
-        if encoded:
-            return _encode_conditions(self._conditions)
-        return self._conditions
+        if not encoded:
+            return self._conditions
+        return [encode_condition((cond["metric"], cond["op"], cond["error"])) for cond in self._conditions]
 
     def clear_conditions(self) -> bool:
         """Clears all quality gate conditions, if quality gate is not built-in
@@ -560,10 +560,7 @@ def count(endpoint: Platform) -> int:
 
 def _encode_conditions(conds: list[dict[str, str]]) -> list[str]:
     """Encode dict conditions in strings"""
-    simple_conds = []
-    for cond in conds:
-        simple_conds.append(encode_condition((cond["metric"], cond["op"], cond["error"])))
-    return simple_conds
+    return [encode_condition((cond["metric"], cond["op"], cond["error"])) for cond in conds]
 
 
 _PERCENTAGE_METRICS = ("density", "ratio", "percent", "security_hotspots_reviewed", "coverage")

--- a/sonar/sif.py
+++ b/sonar/sif.py
@@ -70,6 +70,7 @@ class Sif(object):
         """str() implementation"""
         return str(self.concerned_object)
 
+    @property
     def url(self) -> str:
         """Returns the SQ URL of the SQ instance represented by the SIF"""
         if not self._url:

--- a/sonar/syncer.py
+++ b/sonar/syncer.py
@@ -565,7 +565,7 @@ def _sync_dependency_risks(
     src_object: Union[Project, Branch], tgt_object: Union[Project, Branch], sync_settings: ConfigSettings
 ) -> tuple[list[dict[str, str]], dict[str, int]]:
     """Syncs dependency risks from source to target (unidirectional only)."""
-    from sonar.dependency_risks import DependencyRisk, get_changelogs
+    from sonar.dependency_risks import get_changelogs
 
     src_drs = list(src_object.get_dependency_risks().values())
     tgt_drs = list(tgt_object.get_dependency_risks().values())

--- a/sonar/syncer.py
+++ b/sonar/syncer.py
@@ -79,7 +79,9 @@ def __is_sync_comment(text: str) -> bool:
 
 def __delete_sync_comments(finding: findings.Finding) -> None:
     """Deletes all previous auto-generated sync link comments from a finding."""
-    for cmt in finding.comments().values():
+    # DependencyRisk exposes `comments` as a property; Issue/Hotspot still expose it as a method.
+    comments = finding.comments() if callable(finding.comments) else finding.comments
+    for cmt in comments.values():
         if __is_sync_comment(cmt.get("value", "")) and "commentKey" in cmt:
             finding.delete_comment(cmt["commentKey"])
 

--- a/test/unit/test_branches.py
+++ b/test/unit/test_branches.py
@@ -77,11 +77,11 @@ def test_is_main_is_kept():
     if not verify_branch_support(Branch.get_object, endpoint=project.endpoint, project=project.key, branch_name="develop"):
         return
     obj = Branch.get_object(tutil.SQ, project=project, branch_name="develop")
-    obj._keep_when_inactive = None
+    obj.is_kept_when_inactive = None  # invalidate the cache via the setter
     obj.refresh()
-    assert obj.is_kept_when_inactive() in (True, False)
-    obj._is_main = None
-    assert obj.is_main() in (True, False)
+    assert obj.is_kept_when_inactive in (True, False)
+    obj.is_main = None  # invalidate the cache via the setter
+    assert obj.is_main in (True, False)
 
 
 def test_set_as_main():
@@ -92,8 +92,8 @@ def test_set_as_main():
     dev_br = Branch.get_object(tutil.SQ, project=project, branch_name="develop")
     main_br_name = project.main_branch_name()
     main_br = Branch.get_object(tutil.SQ, project=project, branch_name=main_br_name)
-    assert main_br.is_main()
-    assert not dev_br.is_main()
+    assert main_br.is_main
+    assert not dev_br.is_main
 
     if tutil.SQ.version() < (10, 0, 0):
         with pytest.raises(exceptions.UnsupportedOperation):
@@ -101,8 +101,8 @@ def test_set_as_main():
         return
 
     assert dev_br.set_as_main()
-    assert not main_br.is_main()
-    assert dev_br.is_main()
+    assert not main_br.is_main
+    assert dev_br.is_main
 
     assert main_br.set_as_main()
 
@@ -120,12 +120,12 @@ def test_set_keep_as_inactive():
         return
     dev_br = Branch.get_object(tutil.SQ, project=project, branch_name="develop")
     master_br = Branch.get_object(tutil.SQ, project=project, branch_name="master")
-    assert dev_br.is_kept_when_inactive()
-    assert master_br.is_kept_when_inactive()
+    assert dev_br.is_kept_when_inactive
+    assert master_br.is_kept_when_inactive
 
     assert dev_br.set_keep_when_inactive(False)
-    assert not dev_br.is_kept_when_inactive()
-    assert master_br.is_kept_when_inactive()
+    assert not dev_br.is_kept_when_inactive
+    assert master_br.is_kept_when_inactive
 
     assert dev_br.set_keep_when_inactive(True)
 

--- a/test/unit/test_common_audit.py
+++ b/test/unit/test_common_audit.py
@@ -67,11 +67,11 @@ def test_audit(csv_file: Generator[str]) -> None:
     with open(csv_file, encoding="utf-8") as fd:
         reader = csv.reader(fd)
         next(reader)
-        problems = [tuple((row[1], re.sub(regexp, "[0-9]+ days", re.escape(row[4])))) for row in reader if row[1] not in transient_errors]
+        problems = [(row[1], re.sub(regexp, "[0-9]+ days", re.escape(row[4]))) for row in reader if row[1] not in transient_errors]
     with open(audit_file, encoding="utf-8") as fd:
         reader = csv.reader(fd)
         next(reader)
-        old_problems = [tuple((row[1], re.sub(regexp, "[0-9]+ days", re.escape(row[4])))) for row in reader if row[1] not in transient_errors]
+        old_problems = [(row[1], re.sub(regexp, "[0-9]+ days", re.escape(row[4]))) for row in reader if row[1] not in transient_errors]
     for row in old_problems:
         assert row in problems, f"Problem {row[0]}/{row[1]} not found in new audit comparing {audit_file} and {csv_file}"
     assert problems_present(csv_file, problems)

--- a/test/unit/test_common_sif.py
+++ b/test/unit/test_common_sif.py
@@ -105,12 +105,12 @@ def test_audit_sif_ut() -> None:
     assert sysinfo.server_id() == "XXXB8A4D-XXXSFSbmgIK8PCmM81th"
     assert sysinfo.start_time() == datetime.datetime(2024, 5, 23, 13, 37, 24, tzinfo=datetime.timezone.utc)
     assert sysinfo.store_size() == 131
-    assert sysinfo.url() == "https://sonarqube.acme.com"
+    assert sysinfo.url == "https://sonarqube.acme.com"
     assert sysinfo.web_jvm_cmdline() == "-Xmx512m -Xms128m -XX:+HeapDumpOnOutOfMemoryError"
     assert sysinfo.ce_jvm_cmdline() == "-Xmx1G -Xms128m -XX:+HeapDumpOnOutOfMemoryError"
     assert sysinfo.search_jvm_cmdline() == "-Xmx1G -Xms1G -XX:+HeapDumpOnOutOfMemoryError"
     sysinfo = sif.Sif(json_sif, concerned_object=tutil.SQ)
-    assert sysinfo.url() == tutil.SQ.external_url
+    assert sysinfo.url == tutil.SQ.external_url
     assert str(sysinfo).split("@")[1] == tutil.SQ.external_url
 
 

--- a/test/unit/test_dependency_risks.py
+++ b/test/unit/test_dependency_risks.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python3
 #
 # sonar-tools tests
 # Copyright (C) 2026 Olivier Korach
@@ -21,6 +20,7 @@
 
 """Unit tests for SCA dependency risk export (no live SonarQube required)."""
 
+from typing import Any, Generator
 from datetime import datetime, timezone
 from unittest.mock import MagicMock, patch
 import pytest
@@ -41,7 +41,7 @@ def _mock_endpoint() -> MagicMock:
     return endpoint
 
 
-def _payload(**overrides) -> dict:
+def _payload(**overrides: Any) -> dict[str, Any]:
     base = {
         "id": "risk-1",
         "key": "risk-1-key",
@@ -70,13 +70,14 @@ def _payload(**overrides) -> dict:
 
 
 @pytest.fixture(autouse=True)
-def _clear_cache():
+def _clear_cache() -> Generator[None, None, None]:
     DependencyRisk.CACHE.clear()
     yield
     DependencyRisk.CACHE.clear()
 
 
 def test_field_mapping_vulnerability() -> None:
+    """Test that a DependencyRisk correctly maps fields from the API payload, including nested ones, and constructs a headline."""
     risk = DependencyRisk(
         _mock_endpoint(),
         _payload(),
@@ -120,6 +121,7 @@ def test_api_type_mapping() -> None:
 
 
 def test_transitivity_and_scope_defaults_when_release_missing_flags() -> None:
+    """When release summary flags are false, transitivity falls back to TRANSITIVE and scope to TEST."""
     payload = _payload()
     payload["release"]["directSummary"] = False
     payload["release"]["productionScopeSummary"] = False
@@ -129,11 +131,13 @@ def test_transitivity_and_scope_defaults_when_release_missing_flags() -> None:
 
 
 def test_assignee_none_when_unassigned() -> None:
+    """An absent assignee in the payload should surface as None on the risk."""
     risk = DependencyRisk(_mock_endpoint(), _payload(assignee=None), project_key="p")
     assert risk.assignee is None
 
 
 def test_to_json_excludes_none_and_empty() -> None:
+    """to_json() should drop None/empty fields, omit internal id, and emit a usable risk URL."""
     risk = DependencyRisk(_mock_endpoint(), _payload(), project_key="p", branch="main")
     data = risk.to_json()
     assert "id" not in data
@@ -145,6 +149,7 @@ def test_to_json_excludes_none_and_empty() -> None:
 
 
 def test_to_csv_matches_csv_header() -> None:
+    """to_csv() rows must align column-by-column with CSV_FIELDS and the public CSV header."""
     risk = DependencyRisk(_mock_endpoint(), _payload(), project_key="p")
     row = risk.to_csv()
     header = DependencyRisk.csv_header()
@@ -159,6 +164,7 @@ def test_to_csv_matches_csv_header() -> None:
 
 
 def test_to_sarif_severity_promotes_to_error() -> None:
+    """BLOCKER severity should map to SARIF level 'error' and carry the CVE as ruleId."""
     risk = DependencyRisk(_mock_endpoint(), _payload(severity="BLOCKER"), project_key="p")
     sarif = risk.to_sarif()
     assert sarif["level"] == "error"
@@ -167,11 +173,13 @@ def test_to_sarif_severity_promotes_to_error() -> None:
 
 
 def test_to_sarif_minor_severity_is_warning() -> None:
+    """LOW severity should map to SARIF level 'warning' rather than 'error'."""
     risk = DependencyRisk(_mock_endpoint(), _payload(severity="LOW"), project_key="p")
     assert risk.to_sarif()["level"] == "warning"
 
 
 def test_url_encodes_branch_and_pull_request() -> None:
+    """url() should include exactly one of pullRequest or branch — never both — based on context."""
     pr_risk = DependencyRisk(_mock_endpoint(), _payload(key="pr-risk"), project_key="p", pull_request="42")
     assert "pullRequest=42" in pr_risk.url()
     assert "branch=" not in pr_risk.url()
@@ -211,6 +219,7 @@ def test_search_paginates_and_lookups_project_name() -> None:
 
 
 def test_sca_enabled_returns_false_on_unsupported() -> None:
+    """sca_enabled() should return False on SonarQube versions that predate SCA support."""
     endpoint = _mock_endpoint()
     endpoint.version.return_value = (10, 0, 0)
     assert dr.sca_enabled(endpoint) is False

--- a/test/unit/test_dependency_risks.py
+++ b/test/unit/test_dependency_risks.py
@@ -330,8 +330,13 @@ def _changelog_entry(date_iso: str, key_suffix: str = "") -> DependencyRiskChang
     )
 
 
+def _filter_after(entries: dict, cutoff: datetime) -> dict:
+    """Mirrors the caller-side date filter callers apply to the changelog property."""
+    return {k: v for k, v in entries.items() if v.date_time() > cutoff}
+
+
 def test_changelog_with_after_filters_older_entries() -> None:
-    """changelog(after=...) returns only entries strictly after the cutoff."""
+    """Caller-side filtering of the changelog property keeps only entries strictly after the cutoff."""
     risk = DependencyRisk(_mock_endpoint(), _payload(), project_key="p")
     older = _changelog_entry("2026-01-01T10:00:00+0000", "older")
     newer = _changelog_entry("2026-03-01T10:00:00+0000", "newer")
@@ -339,7 +344,7 @@ def test_changelog_with_after_filters_older_entries() -> None:
     risk._comments = {}  # short-circuit the lazy loader
 
     cutoff = datetime(2026, 2, 1, tzinfo=timezone.utc)
-    filtered = risk.changelog(after=cutoff)
+    filtered = _filter_after(risk.changelog, cutoff)
 
     assert list(filtered.keys()) == ["b"]
     assert filtered["b"] is newer
@@ -352,11 +357,11 @@ def test_changelog_with_after_in_future_returns_empty() -> None:
     risk._comments = {}
 
     cutoff = datetime(2030, 1, 1, tzinfo=timezone.utc)
-    assert risk.changelog(after=cutoff) == {}
+    assert _filter_after(risk.changelog, cutoff) == {}
 
 
 def test_changelog_after_excludes_entries_with_matching_timestamp() -> None:
-    """The filter is strictly greater-than: entries equal to the cutoff are excluded."""
+    """The caller-side filter is strictly greater-than: entries equal to the cutoff are excluded."""
     risk = DependencyRisk(_mock_endpoint(), _payload(), project_key="p")
     boundary = "2026-02-15T12:00:00+0000"
     risk._changelog = {
@@ -366,13 +371,13 @@ def test_changelog_after_excludes_entries_with_matching_timestamp() -> None:
     risk._comments = {}
 
     cutoff = datetime(2026, 2, 15, 12, 0, 0, tzinfo=timezone.utc)
-    filtered = risk.changelog(after=cutoff)
+    filtered = _filter_after(risk.changelog, cutoff)
 
     assert list(filtered.keys()) == ["b"]
 
 
-def test_changelog_with_after_lazy_loads_when_unloaded() -> None:
-    """changelog() must trigger _load_changelog_and_comments when _changelog is None."""
+def test_changelog_property_lazy_loads_when_unloaded() -> None:
+    """The changelog property must trigger _load_changelog_and_comments when _changelog is None."""
     risk = DependencyRisk(_mock_endpoint(), _payload(), project_key="p")
 
     def fake_load() -> None:
@@ -380,7 +385,7 @@ def test_changelog_with_after_lazy_loads_when_unloaded() -> None:
         risk._comments = {}
 
     with patch.object(risk, "_load_changelog_and_comments", side_effect=fake_load) as load:
-        result = risk.changelog(after=datetime(2026, 1, 1, tzinfo=timezone.utc))
+        result = risk.changelog
 
     load.assert_called_once()
     assert "a" in result

--- a/test/unit/test_dependency_risks.py
+++ b/test/unit/test_dependency_risks.py
@@ -340,8 +340,8 @@ def test_changelog_with_after_filters_older_entries() -> None:
     risk = DependencyRisk(_mock_endpoint(), _payload(), project_key="p")
     older = _changelog_entry("2026-01-01T10:00:00+0000", "older")
     newer = _changelog_entry("2026-03-01T10:00:00+0000", "newer")
-    risk._changelog = {"a": older, "b": newer}
-    risk._comments = {}  # short-circuit the lazy loader
+    risk.changelog = {"a": older, "b": newer}
+    risk.comments = {}  # short-circuit the lazy loader
 
     cutoff = datetime(2026, 2, 1, tzinfo=timezone.utc)
     filtered = _filter_after(risk.changelog, cutoff)
@@ -353,8 +353,8 @@ def test_changelog_with_after_filters_older_entries() -> None:
 def test_changelog_with_after_in_future_returns_empty() -> None:
     """A cutoff after every entry returns an empty dict, not the full changelog."""
     risk = DependencyRisk(_mock_endpoint(), _payload(), project_key="p")
-    risk._changelog = {"a": _changelog_entry("2026-01-01T10:00:00+0000")}
-    risk._comments = {}
+    risk.changelog = {"a": _changelog_entry("2026-01-01T10:00:00+0000")}
+    risk.comments = {}
 
     cutoff = datetime(2030, 1, 1, tzinfo=timezone.utc)
     assert _filter_after(risk.changelog, cutoff) == {}
@@ -364,11 +364,11 @@ def test_changelog_after_excludes_entries_with_matching_timestamp() -> None:
     """The caller-side filter is strictly greater-than: entries equal to the cutoff are excluded."""
     risk = DependencyRisk(_mock_endpoint(), _payload(), project_key="p")
     boundary = "2026-02-15T12:00:00+0000"
-    risk._changelog = {
+    risk.changelog = {
         "a": _changelog_entry(boundary, "exact"),
         "b": _changelog_entry("2026-02-15T12:00:01+0000", "after"),
     }
-    risk._comments = {}
+    risk.comments = {}
 
     cutoff = datetime(2026, 2, 15, 12, 0, 0, tzinfo=timezone.utc)
     filtered = _filter_after(risk.changelog, cutoff)
@@ -381,8 +381,8 @@ def test_changelog_property_lazy_loads_when_unloaded() -> None:
     risk = DependencyRisk(_mock_endpoint(), _payload(), project_key="p")
 
     def fake_load() -> None:
-        risk._changelog = {"a": _changelog_entry("2026-04-01T10:00:00+0000")}
-        risk._comments = {}
+        risk.changelog = {"a": _changelog_entry("2026-04-01T10:00:00+0000")}
+        risk.comments = {}
 
     with patch.object(risk, "_load_changelog_and_comments", side_effect=fake_load) as load:
         result = risk.changelog

--- a/test/unit/test_devops.py
+++ b/test/unit/test_devops.py
@@ -50,9 +50,9 @@ def test_get_object_gh() -> None:
     plt = devops.DevopsPlatform.get_object(endpoint=tutil.SQ, key=GH_KEY)
     assert plt.url == "https://api.github.com"
     if tutil.SQ.version() >= (10, 0, 0):
-        assert plt._specific["appId"] == "946159"
+        assert plt.specific["appId"] == "946159"
     else:
-        assert plt._specific["appId"] == "1096234"
+        assert plt.specific["appId"] == "1096234"
     assert str(plt) == f"devops platform '{GH_KEY}'"
 
 

--- a/test/unit/test_platform.py
+++ b/test/unit/test_platform.py
@@ -75,19 +75,19 @@ def test_import() -> None:
 
 
 def test_sys_info() -> None:
-    data = tutil.SC.sys_info()
+    data = tutil.SC.sys_info
     assert data == {"System": {"Server ID": "sonarcloud"}}
 
-    data = tutil.SQ.sys_info()
+    data = tutil.SQ.sys_info
     assert "System" in data
 
 
 def test_wrong_url() -> None:
     tutil.TEST_SQ.local_url = "http://localhost:3337"
 
-    tutil.TEST_SQ._sys_info = None
+    tutil.TEST_SQ.sys_info = None  # invalidate cache via setter
     with pytest.raises(requests.exceptions.ConnectionError):
-        tutil.TEST_SQ.sys_info()
+        _ = tutil.TEST_SQ.sys_info
 
     with pytest.raises(requests.exceptions.ConnectionError):
         tutil.TEST_SQ.global_permissions()

--- a/test/unit/test_portfolios.py
+++ b/test/unit/test_portfolios.py
@@ -89,7 +89,7 @@ def test_create_delete(get_test_portfolio: Generator[pf.Portfolio]) -> None:
     portfolio: pf.Portfolio = get_test_portfolio
     assert portfolio is not None
     assert portfolio.key.startswith(f"{tutil.TEMP_KEY}-portfolio")
-    assert "none" in portfolio.selection_mode()
+    assert "none" in portfolio.selection_mode
     assert portfolio.name.startswith(f"{tutil.TEMP_KEY}-portfolio")
     key = portfolio.key
     assert portfolio.is_toplevel()
@@ -104,15 +104,15 @@ def test_add_project(get_test_portfolio: Generator[pf.Portfolio]) -> None:
     if not __verify_support():
         pytest.skip(__UNSUPPORTED_MESSAGE)
     p = get_test_portfolio
-    assert "none" in p.selection_mode()
+    assert "none" in p.selection_mode
 
     project = projects.Project.get_object(endpoint=tutil.SQ, key=tutil.LIVE_PROJECT)
-    assert "none" in p.selection_mode()
-    p._selection_mode = None
-    p.selection_mode()
+    assert "none" in p.selection_mode
+    p.selection_mode = None  # invalidate cache via setter
+    _ = p.selection_mode  # trigger reload path
     assert not p.has_project(project.key)
     p.add_projects({project.key})
-    mode = p.selection_mode()
+    mode = p.selection_mode
     assert "manual" in mode
     assert mode["manual"] == {tutil.LIVE_PROJECT: {c.DEFAULT_BRANCH}}
     assert p.projects() == {tutil.LIVE_PROJECT: {c.DEFAULT_BRANCH}}
@@ -133,12 +133,12 @@ def test_tags_mode(get_test_portfolio: Generator[pf.Portfolio]) -> None:
     p = get_test_portfolio
     in_tags = ["foss", "favorites"]
     p.set_tags_mode(in_tags)
-    mode = p.selection_mode()
+    mode = p.selection_mode
     assert "tags" in mode and mode["tags"].sort() == in_tags.sort()
     assert mode["branch"] == c.DEFAULT_BRANCH
 
     p.set_tags_mode(tags=in_tags, branch="some_branch")
-    mode = p.selection_mode()
+    mode = p.selection_mode
     assert "tags" in mode and mode["tags"].sort() == in_tags.sort()
     assert mode["branch"] == "some_branch"
     assert p.recompute()
@@ -151,14 +151,14 @@ def test_regexp_mode(get_test_portfolio: Generator[pf.Portfolio]) -> None:
     p = get_test_portfolio
     in_regexp = "^FAVORITES.*$"
     p.set_regexp_mode(in_regexp)
-    mode = p.selection_mode()
+    mode = p.selection_mode
     assert "regexp" in mode and mode["regexp"] == in_regexp
     assert "branch" in mode and mode["branch"] == c.DEFAULT_BRANCH
     assert p.recompute()
 
     in_regexp = "^BRANCH_FAVORITES.*$"
     p.set_regexp_mode(regexp=in_regexp, branch="develop")
-    mode = p.selection_mode()
+    mode = p.selection_mode
     assert "regexp" in mode and mode["regexp"] == in_regexp
     assert "branch" in mode and mode["branch"] == "develop"
     assert p.recompute()
@@ -170,9 +170,9 @@ def test_remaining_projects_mode(get_test_portfolio: Generator[pf.Portfolio]) ->
         pytest.skip(__UNSUPPORTED_MESSAGE)
     p = get_test_portfolio
     p.set_remaining_projects_mode()
-    assert p._selection_mode == {"rest": True, "branch": c.DEFAULT_BRANCH}
+    assert p.selection_mode == {"rest": True, "branch": c.DEFAULT_BRANCH}
     p.set_remaining_projects_mode("develop")
-    assert p._selection_mode == {"rest": True, "branch": "develop"}
+    assert p.selection_mode == {"rest": True, "branch": "develop"}
 
 
 def test_none_mode(get_test_portfolio: Generator[pf.Portfolio]) -> None:
@@ -181,9 +181,9 @@ def test_none_mode(get_test_portfolio: Generator[pf.Portfolio]) -> None:
         pytest.skip(__UNSUPPORTED_MESSAGE)
     p = get_test_portfolio
     p.set_remaining_projects_mode()
-    assert p._selection_mode == {"rest": True, "branch": c.DEFAULT_BRANCH}
+    assert p.selection_mode == {"rest": True, "branch": c.DEFAULT_BRANCH}
     p.set_none_mode()
-    assert p._selection_mode == {}
+    assert p.selection_mode == {}
 
 
 def test_attributes(get_test_portfolio: Generator[pf.Portfolio]) -> None:
@@ -201,7 +201,7 @@ def test_attributes(get_test_portfolio: Generator[pf.Portfolio]) -> None:
     assert data["key"] == p.key
     p.set_description("some description of a portfolio")
     p.refresh()
-    assert p._description == "some description of a portfolio"
+    assert p.description == "some description of a portfolio"
 
 
 def test_permissions_1(get_test_portfolio: Generator[pf.Portfolio]) -> None:

--- a/test/unit/test_sif.py
+++ b/test/unit/test_sif.py
@@ -45,7 +45,7 @@ class TestSifBasic:
         sif_obj = sif.Sif(json_sif)
         assert sif_obj.json == json_sif
         assert sif_obj.concerned_object is None
-        assert sif_obj._url is None
+        assert sif_obj._url is None  # pre-lazy-load backing store
 
     def test_sif_creation_with_concerned_object(self):
         """Test Sif creation with concerned object"""
@@ -79,23 +79,23 @@ class TestSifBasic:
         assert str(sif_obj) == str(mock_object)
 
     def test_sif_url_with_concerned_object(self):
-        """Test Sif url() method with concerned object"""
+        """Test Sif url property with concerned object"""
         with open(f"{tutil.FILES_ROOT}/sif1.json", encoding="utf-8") as f:
             json_sif = json.loads(f.read())
         sif_obj = sif.Sif(json_sif)
-        assert sif_obj.url() == "https://sonarqube.acme.com"
+        assert sif_obj.url == "https://sonarqube.acme.com"
 
     def test_sif_url_without_concerned_object(self):
-        """Test Sif url() method without concerned object"""
+        """Test Sif url property without concerned object"""
         with open(f"{tutil.FILES_ROOT}/sif1.json", encoding="utf-8") as f:
             json_sif = json.loads(f.read())
         json_sif["Settings"].pop("sonar.core.serverBaseURL", None)
         sif_obj = sif.Sif(json_sif)
         # Should return empty string as no serverBaseURL in settings
-        assert sif_obj.url() == ""
+        assert sif_obj.url == ""
 
     def test_sif_url_with_server_base_url(self):
-        """Test Sif url() method with serverBaseURL in settings"""
+        """Test Sif url property with serverBaseURL in settings"""
         with open(f"{tutil.FILES_ROOT}/sif1.json", encoding="utf-8") as f:
             json_sif = json.loads(f.read())
 
@@ -103,7 +103,7 @@ class TestSifBasic:
         json_sif["Settings"]["sonar.core.serverBaseURL"] = "https://custom.sonarqube.com"
 
         sif_obj = sif.Sif(json_sif)
-        assert sif_obj.url() == "https://custom.sonarqube.com"
+        assert sif_obj.url == "https://custom.sonarqube.com"
 
 
 class TestSifEdition:
@@ -154,7 +154,7 @@ class TestSifEdition:
         with open(f"{tutil.FILES_ROOT}/sif1.json", encoding="utf-8") as f:
             json_sif = json.loads(f.read())
         sif_obj = sif.Sif(json_sif)
-        assert sif_obj.url() == "https://sonarqube.acme.com"
+        assert sif_obj.url == "https://sonarqube.acme.com"
         assert sif_obj.start_time() == datetime(2024, 5, 23, 13, 37, 24, tzinfo=timezone.utc)
         assert sif_obj.store_size() == 131
 


### PR DESCRIPTION
## Summary
- Convert parameterless getter methods to `@property` and add new `@property` wrappers wherever external code was reaching for private state (`Sif.url`, `Branch.is_main`/`is_kept_when_inactive`, `ApplicationBranch.is_main`, `Portfolio.selection_mode`, `Platform.sys_info`, `DependencyRisk.changelog`/`comments`, plus new `Issue.tags`, `Portfolio.description`, `DevopsPlatform.specific`). Setters added where tests invalidate caches.
- Bridge the polymorphic `Finding`-protocol gap in `syncer.__delete_sync_comments` so it handles both method-style access (Issue/Hotspot) and property-style access (DependencyRisk).
- Fix a latent bug at `sonar/issues.py:1051` where `i.tags` (previously undefined) was referenced alongside `i._tags`; both now route through the new `tags` property.
- Tidy up types and small idioms: parameterized return types on `get_dependency_risks` (Branch/Component/PullRequest), `raise ... from e` on re-raises (`projects_cli`, `components`), list comprehensions and dropped redundant `tuple()` calls (`qualitygates`, `test_common_audit`), `DependencyRisk.__str__` now includes project/branch/PR context, `get_tags` accepts `**kwargs` to match base, and a few long lines collapsed to fit the 150-char limit.

## Test plan
- [ ] `conf/run_linters.sh '' true 'ruff,pylint,flake8'` — no new findings over baseline
- [ ] `poetry run pytest test/unit/` against a live SQ instance
- [ ] Spot-check `sonar-findings-export --types dependencyRisk` on an EE 2025.4 instance
- [ ] Spot-check `sonar-findings-sync` between two projects to exercise the property/method polymorphism guard in `syncer.__delete_sync_comments`

🤖 Generated with [Claude Code](https://claude.com/claude-code)