### PR TITLE
Fix KeyError on period field in sonar-measures-export on SonarQube Cloud (#2400)

### DIFF
--- a/sonar/measures.py
+++ b/sonar/measures.py
@@ -65,7 +65,7 @@ class Measure(SqObject):
         self.component_key = data.get(self.__class__.__CONCERNED_OBJECT)
         self.branch = None
         self.pull_request = None
-        self.value = self.__converted_value(data.get("value") or data["period"].get("value"))
+        self.value = self.__converted_value(_search_value(data))
 
     @classmethod
     def get_object(cls, endpoint: Platform, metric_key: str, component: ConcernedObject, use_cache: bool = True) -> Measure:
@@ -84,7 +84,7 @@ class Measure(SqObject):
     def reload(self, data: ApiPayload) -> Measure:
         """Reloads a Measure object from API data"""
         super().reload(data)
-        self.value = self.__converted_value(data["value"])
+        self.value = self.__converted_value(_search_value(data))
         return self
 
     def refresh(self) -> Measure:


### PR DESCRIPTION
## Summary
- Fixes #2400 — `sonar-measures-export` crashed with `KeyError: 'period'` when run against SonarQube Cloud for any new-code-period metric (e.g. `new_vulnerabilities`).
- Root cause: SQC returns `"periods"` (plural list) for these metrics, but `Measure.__init__` and `Measure.reload` hardcoded `data["period"]` (singular dict).
- Fix: route both call sites through the existing `_search_value()` helper, which already handles `value`, `periods`, and singular `period` payload shapes.

## Test plan
- [x] Reproduced payload from issue traceback against the fixed `Measure` class — value parses correctly.
- [x] Verified legacy `value` and singular `period` payloads still parse correctly.
- [ ] Re-run `sonar-measures-export -o okorach-oss -t $SONAR_TOKEN_SONARCLOUD -v DEBUG` against SonarCloud after merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
