### PR TITLE
Fix sonar-rules CSV export missing MQR fields on SonarQube Cloud (#2404)

### DIFF
--- a/cli/rules_cli.py
+++ b/cli/rules_cli.py
@@ -27,7 +27,6 @@ import sonar.logging as log
 from sonar import rules, platform, exceptions, errcodes, version, qualityprofiles
 import sonar.utilities as sutil
 import sonar.util.misc as util
-import sonar.util.constants as c
 import sonar.util.common_helper as chelp
 
 TOOL_NAME = "sonar-rules"
@@ -49,7 +48,7 @@ def __write_rules_csv(file: str, rule_list: dict[str, rules.Rule], separator: st
     with util.open_file(file) as fd:
         csvwriter = csv.writer(fd, delimiter=separator, quotechar='"', quoting=csv.QUOTE_MINIMAL)
         print("# ", file=fd, end="")
-        if list(rule_list.values())[0].endpoint.version() >= c.MQR_INTRO_VERSION:
+        if list(rule_list.values())[0].endpoint.is_mqr_mode():
             csvwriter.writerow(rules.CSV_EXPORT_FIELDS)
         else:
             csvwriter.writerow(rules.LEGACY_CSV_EXPORT_FIELDS)

--- a/sonar/rules.py
+++ b/sonar/rules.py
@@ -393,7 +393,7 @@ class Rule(SqObject):
             data["ruleType"] = "TEMPLATE"
         elif self.template_key:
             data["ruleType"] = "INSTANTIATED"
-        if self.endpoint.version() >= c.MQR_INTRO_VERSION:
+        if self.endpoint.is_mqr_mode():
             data["legacySeverity"] = data.pop("severity", "")
             data["legacyType"] = data.pop("type", "")
             for qual in idefs.MQR_QUALITIES:


### PR DESCRIPTION
## Summary
- Fixes #2404: `sonar-rules -e` against SonarCloud exported only legacy fields (type, severity), missing MQR attributes
- Root cause: `Platform.version()` returns `(0,0,0)` for SonarCloud, so the `version() >= MQR_INTRO_VERSION` check fell through to the legacy CSV branch — even though SonarCloud is always in MQR mode
- Use `is_mqr_mode()` instead in both `cli/rules_cli.py` (CSV header) and `sonar/rules.py` (CSV row in `Rule.to_csv()`)

## Test plan
- [ ] Run `sonar-rules -e -f rules.csv` against SonarCloud and confirm the header is `key,language,repo,securityImpact,reliabilityImpact,maintainabilityImpact,name,ruleType,tags,legacySeverity,legacyType`
- [ ] Run `sonar-rules -e -f rules.csv` against SonarQube Server 2025.1+ and confirm output is unchanged
- [ ] Run `sonar-rules -e -f rules.csv` against SonarQube Server <10.2 and confirm legacy header is still used

🤖 Generated with [Claude Code](https://claude.com/claude-code)