### PR TITLE
`fix: prevent O(N²) API calls in Branch.new_code() during export`

### DIFF
--- a/sonar/branches.py
+++ b/sonar/branches.py
@@ -211,7 +211,9 @@ class Branch(components.Component):
                     self._new_code = new_code
                 else:
                     # While we're there let's store the new code of other branches
-                    Branch.get_object(endpoint=self.endpoint, project=self.concerned_object, branch_name=b["branchKey"])._new_code = new_code
+                    Branch.get_object(endpoint=self.endpoint, project=self.concerned_object, branch_name=b["branchKey"], use_cache=True)._new_code = new_code
+        if self._new_code is None:
+            self._new_code = ""  # inherited period — prevent perpetual re-fetch
         return self._new_code
 
     def set_keep_when_inactive(self, keep: bool) -> bool:


### PR DESCRIPTION
closes to https://github.com/okorach/sonar-tools/issues/2403 

### Problem

Two bugs in `Branch.new_code()` compound each other to produce quadratic API call behaviour
during project export on instances with multi-branch projects using inherited new code periods
(the most common configuration).

**Bug 1 — `get_object()` called with `use_cache=False` (default)**

Since 3.19, `Branch.get_object()` accepts a `use_cache` parameter that defaults to `False`.
When `new_code()` pre-fills sibling branches, it calls `get_object()` without `use_cache=True`,
unconditionally hitting `project_branches/list` for each sibling branch — even though those
objects are already in cache.

In 3.16, `get_object()` always returned from cache if the object existed; no extra API calls
were ever made from `new_code()`.

**Bug 2 — `None` returned for inherited periods causes perpetual cache miss**

`settings.new_code_to_string()` returns `None` when `data.get("inherited")` is `True`.
After the `newCodePeriods` loop, `self._new_code` remains `None` for any branch with an
inherited period. On every subsequent call to `new_code()`, the guard `if self._new_code is None`
fires again, re-triggering the full fetch cycle.

**Combined effect**: N² `project_branches/list` calls per project (N = branch count), multiplied
by 3 because `Branch.export()` calls `self.new_code()` three times. On a 352-project instance
with ~10 branches each, this produces ~95,000 extra API calls, pushing a 3-minute export beyond
1 hour.

### Testing

Manually validated on a SonarQube Server instance with 352 projects:

| Version / patch      | Export duration |
|----------------------|-----------------|
| 3.19 (unpatched)     | >60 minutes     |
| 3.19 + this fix      | <6 minutes      |

### Notes

- `Branch.export()` calls `self.new_code()` three times (lines 1, 3, 4 of the method body).
  Deduplicating those calls would further reduce overhead but is out of scope for this fix.
- `Branch.refresh()` still calls `get_object(use_cache=False)` intentionally — that call site
  is correct and untouched.
