### PR TITLE
Fix: return most recent analysis date in `last_analysis(include_branches=True)` method

### DIFF
--- a/sonar/projects.py
+++ b/sonar/projects.py
@@ -211,7 +211,19 @@ class Project(Component):
         if self._branches_last_analysis:
             return self._branches_last_analysis
 
-        self._branches_last_analysis = self._last_analysis
+        # Calculate the most recent analysis date across all branches
+        most_recent = self._last_analysis
+        try:
+            for branch_obj in self.branches().values():
+                branch_analysis = branch_obj.last_analysis()
+                if branch_analysis:
+                    if most_recent is None or branch_analysis > most_recent:
+                        most_recent = branch_analysis
+        except exceptions.UnsupportedOperation:
+            # Community Edition doesn't support branches
+            pass
+
+        self._branches_last_analysis = most_recent
         return self._branches_last_analysis
 
     def loc(self) -> int:

--- a/test/unit/test_projects.py
+++ b/test/unit/test_projects.py
@@ -429,3 +429,24 @@ def test_sorted_search() -> None:
 
     proj_list = projects.Project.search(tutil.SQ, use_cache=True)
     assert sorted(proj_list.keys()) == list(proj_list.keys())
+
+
+def test_last_analysis() -> None:
+    """test_last_analysis"""
+    proj = Project.get_object(tutil.SQ, key=tutil.LIVE_PROJECT)
+    last_analysis = proj.last_analysis()
+    assert last_analysis is not None
+    assert isinstance(last_analysis, type(proj.last_analysis()))
+
+
+def test_last_analysis_with_branches() -> None:
+    """test_last_analysis_with_branches"""
+    if tutil.SQ.edition() == c.CE:
+        pytest.skip("Branches unsupported in SonarQube Community Edition")
+    proj = Project.get_object(tutil.SQ, key=tutil.LIVE_PROJECT)
+    last_analysis_without_branches = proj.last_analysis(include_branches=False)
+    last_analysis_with_branches = proj.last_analysis(include_branches=True)
+    assert last_analysis_with_branches is not None
+    # The result with branches should be >= the result without branches
+    if last_analysis_without_branches:
+        assert last_analysis_with_branches >= last_analysis_without_branches


### PR DESCRIPTION
closes to https://github.com/okorach/sonar-tools/issues/2408

### Problem

The `Project.last_analysis(include_branches=True)` method in the `sonar-tools` library does not work correctly. It returns `None` even when one or more branches of the project have been analyzed.

#### Current behavior

```python
def last_analysis(self, include_branches: bool = False) -> Optional[datetime]:
    if not self._last_analysis:
        self.get_navigation_data()
    if not include_branches:
        return self._last_analysis
    if self._branches_last_analysis:
        return self._branches_last_analysis

    # ❌ BUG: Never actually calculates the real date from branches
    self._branches_last_analysis = self._last_analysis
    return self._branches_last_analysis
```

**Problem**: The method copies `self._last_analysis` (the main branch date) without ever checking other branches. If the main branch has no analysis but another branch does, the method returns `None`.

### Proposed Solution

The fix iterates through all project branches and returns the **most recent** analysis date.