### PR TITLE
Fix run_tests.sh to use sqs instead of sonar CLI

### DIFF
--- a/conf/run_tests.sh
+++ b/conf/run_tests.sh
@@ -35,7 +35,7 @@ cd "${ROOT_DIR}" || exit 1
 # on records pointing to test files that have since been removed/renamed.
 poetry run coverage erase
 
-sonar start -i test
+sqs start -i test
 
 testList="${1:-"latest cb 99 cloud"}"
 for target in ${testList}


### PR DESCRIPTION
## Summary
- `conf/run_tests.sh` was invoking `sonar start -i test`, which is the old CLI name; switch to `sqs start -i test` to match the current tool.

## Test plan
- [ ] Run `conf/run_tests.sh` and confirm the test container starts via `sqs`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)