### PR TITLE
Backport #2406 to 3.19.x: prevent O(N²) API calls in Branch.new_code()

### DIFF
--- a/sonar/branches.py
+++ b/sonar/branches.py
@@ -200,7 +200,9 @@ class Branch(components.Component):
                     self._new_code = new_code
                 else:
                     # While we're there let's store the new code of other branches
-                    Branch.get_object(endpoint=self.endpoint, project=self.concerned_object, branch_name=b["branchKey"])._new_code = new_code
+                    Branch.get_object(endpoint=self.endpoint, project=self.concerned_object, branch_name=b["branchKey"], use_cache=True)._new_code = new_code
+        if self._new_code is None:
+            self._new_code = ""  # inherited period — prevent perpetual re-fetch
         return self._new_code
 
     def set_keep_when_inactive(self, keep: bool) -> bool:


### PR DESCRIPTION
## Summary
- Backport of [#2406](https://github.com/okorach/sonar-tools/pull/2406) onto `branch-3.19.x`.
- Uses cache when fetching new code for branches to avoid O(N²) API calls during export.

## Test plan
- [ ] Run a multi-branch project export against a 3.19.x deployment and confirm the per-branch new-code API is no longer called N² times.

🤖 Generated with [Claude Code](https://claude.com/claude-code)