### PR TITLE
Bump version to 3.19.1

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "sonar-tools"
-version = "3.19"
+version = "3.19.1"
 description = "A collection of utility tools for the SonarQube ecosystem"
 authors = [
   {name = "Olivier Korach", email = "olivier.korach@gmail.com"},

--- a/sonar/version.py
+++ b/sonar/version.py
@@ -20,5 +20,5 @@
 
 """sonar-tools project version"""
 
-PACKAGE_VERSION = "3.19"
+PACKAGE_VERSION = "3.19.1"
 MIGRATION_TOOL_VERSION = "0.7"


### PR DESCRIPTION
## Summary
- Bump `pyproject.toml` and `sonar/version.py` to `3.19.1` ahead of patch release with the #2406 backport ([#2412](https://github.com/okorach/sonar-tools/pull/2412)).

🤖 Generated with [Claude Code](https://claude.com/claude-code)