### PR TITLE
Port coverage cache cleanup in run_tests.sh from 3.20.x

### DIFF
--- a/conf/run_tests.sh
+++ b/conf/run_tests.sh
@@ -38,7 +38,7 @@ poetry run coverage erase
 sqs start -i test
 
 if [[ "$1" == "" ]]; then
-    rm -rf "${ROOT_DIR}/.coverage
+    rm -rf "${ROOT_DIR}/.coverage"
 fi
 testList="${1:-"latest cb 99 cloud"}"
 for target in ${testList}

--- a/conf/run_tests.sh
+++ b/conf/run_tests.sh
@@ -37,6 +37,9 @@ poetry run coverage erase
 
 sqs start -i test
 
+if [[ "$1" == "" ]]; then
+    rm -rf "${ROOT_DIR}/.coverage
+fi
 testList="${1:-"latest cb 99 cloud"}"
 for target in ${testList}
 do


### PR DESCRIPTION
## Summary

Port the `conf/run_tests.sh` coverage-cache fix from `branch-3.20.x` (released as part of 3.20.1) to `master`.

- Add `rm -rf "${ROOT_DIR}/.coverage"` when no target arg is passed, so stale per-target coverage files from prior runs don't pollute results.
- The original backport (`7bbf48f1`) introduced a missing closing `"` in the path; `c0fe780b` fixed it. Both are included.
- The `sonar` → `sqs` portion of the original commit was already applied on `master` (commit `c3af4f85`), so only the new block is effectively added here.

## Test plan

- [ ] `bash conf/run_tests.sh` with no args removes `.coverage` before running the matrix
- [ ] `bash conf/run_tests.sh latest` (with a target arg) does NOT remove `.coverage`
- [ ] `poetry run coverage xml` at the end still produces a valid `build/coverage.xml`

Cherry-picked from `branch-3.20.x`: `7bbf48f1`, `c0fe780b`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
