### PR TITLE
Fix #2087: cache new code periods on the Project, not the Branch

### DIFF
--- a/sonar/branches.py
+++ b/sonar/branches.py
@@ -200,18 +200,13 @@ class Branch(components.Component):
 
     def new_code(self) -> str:
         """returns the branch new code period definition"""
-        if self._new_code is None and self.endpoint.is_sonarcloud():
-            self._new_code = settings.new_code_to_string({"inherited": True})
-        elif self._new_code is None:
-            api, _, params, _ = self.endpoint.api.get_details(self, Oper.LIST_NEW_CODE_PERIODS, project=self.concerned_object.key)
-            data = json.loads(self.get(api, params=params).text)
-            for b in data["newCodePeriods"]:
-                new_code = settings.new_code_to_string(b)
-                if b["branchKey"] == self.name:
-                    self._new_code = new_code
-                else:
-                    # While we're there let's store the new code of other branches
-                    Branch.get_object(endpoint=self.endpoint, project=self.concerned_object, branch_name=b["branchKey"], use_cache=True)._new_code = new_code
+        if self._new_code is None:
+            if self.endpoint.is_sonarcloud():
+                self._new_code = settings.new_code_to_string({"inherited": True})
+            else:
+                # Delegate to the parent project so a single api/new_code_periods/list
+                # call is shared (and cached) across every branch of the project.
+                self._new_code = self.concerned_object.branch_new_code_periods().get(self.name, "")
         if self._new_code is None:
             self._new_code = ""  # inherited period — prevent perpetual re-fetch
         return self._new_code

--- a/sonar/projects.py
+++ b/sonar/projects.py
@@ -113,6 +113,7 @@ class Project(Component):
         self._ncloc_with_branches: Optional[int] = None
         self._binding: Optional[dict[str, str]] = None
         self._new_code: Optional[str] = None
+        self._branch_new_code_periods: Optional[dict[str, str]] = None
         self._ci: Optional[str] = None
         self._revision: Optional[str] = None
         self.__class__.CACHE.put(self)
@@ -979,6 +980,23 @@ class Project(Component):
             self._new_code = new_code.value if new_code else ""
             log.info("%s new code is %s", self, self._new_code)
         return self._new_code
+
+    def branch_new_code_periods(self) -> dict[str, str]:
+        """:return: Mapping of {branchKey: new_code_string} for every branch of this project.
+
+        The result of api/new_code_periods/list is cached on the Project so that
+        repeated lookups across many Branch.new_code() calls only trigger one
+        HTTP round-trip per project. Returns an empty dict on SonarCloud, which
+        does not expose per-branch new code period configuration.
+        """
+        if self._branch_new_code_periods is None:
+            if self.endpoint.is_sonarcloud():
+                self._branch_new_code_periods = {}
+            else:
+                api, _, params, _ = self.endpoint.api.get_details(branches.Branch, Oper.LIST_NEW_CODE_PERIODS, project=self.key)
+                data = json.loads(self.get(api, params=params).text)
+                self._branch_new_code_periods = {b["branchKey"]: settings.new_code_to_string(b) for b in data["newCodePeriods"]}
+        return self._branch_new_code_periods
 
     def permissions(self) -> pperms.ProjectPermissions:
         """:return: The project permissions


### PR DESCRIPTION
## Summary

Fixes #2087.

`Branch.new_code()` previously called `api/new_code_periods/list` itself, keyed by project. When `sonar-config` walks a project's branches it would hit the same endpoint repeatedly for the same project. The existing "while we're there, populate the other branches" trick on the `Branch` object only worked when the call sequence happened to amortize and depended on each `Branch` keeping its `_new_code` attribute alive in the cache.

## Change

Move the cache to its natural home — the `Project` object:

- **`Project.branch_new_code_periods()`** (new, `sonar/projects.py`) — calls `api/new_code_periods/list` once per project and caches a `{branchKey: new_code_string}` dict on the `Project` instance.
- **`Branch.new_code()`** (`sonar/branches.py`) — now does a dict lookup against the project's cached map instead of making its own API call. The sibling-branch population trick is gone because the project owns the data.

SonarCloud behavior is unchanged: branches keep returning the `"inherited"` sentinel, and `Project.branch_new_code_periods()` short-circuits to `{}` if it is ever called on SQC.

## Test plan

- [ ] `test/unit/test_branches.py::test_new_code` (and other branch tests) still pass against `latest`, `cb`, `99`
- [ ] `sonar-config -e ...` shows exactly one `GET api/new_code_periods/list?project=<key>` per project in DEBUG logs (vs. one per branch before)
- [ ] Existing `Branch.new_code()` callers see the same string values as before (per branch: explicit value when configured, `""` for inherited)
- [ ] Cleared project cache still raises `ObjectNotFound` when the project key is bogus (`test_branches.py:70` style)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
