### PR TITLE
Fix #2109: build rule description from descriptionSections

### DIFF
--- a/sonar/rules.py
+++ b/sonar/rules.py
@@ -160,6 +160,27 @@ CSV_EXPORT_FIELDS = [
 LEGACY_CSV_EXPORT_FIELDS = ["key", "language", "repo", "type", "severity", "name", "ruleType", "tags"]
 
 
+def _build_description(data: dict) -> Optional[str]:
+    """Builds the rule HTML description from the api/rules/search payload.
+
+    Recent SonarQube versions return the description in ``descriptionSections``
+    (an array of ``{key, content}`` entries) and no longer in ``description``.
+    Behaviour:
+
+    * If ``descriptionSections`` is present and contains a single entry with
+      ``key == "default"``, the description is just that entry's ``content``.
+    * If ``descriptionSections`` is present with multiple entries, the
+      description is the concatenation of ``<h1>{key}</h1>{content}`` for each.
+    * Otherwise, fall back to the legacy ``description`` field.
+    """
+    sections = data.get("descriptionSections")
+    if sections:
+        if len(sections) == 1 and sections[0].get("key") == "default":
+            return sections[0].get("content", "")
+        return "".join(f"<h1>{s.get('key', '')}</h1>{s.get('content', '')}" for s in sections)
+    return data.get("description")
+
+
 class Rule(SqObject):
     """Abstraction of the Sonar Rule concept"""
 
@@ -186,7 +207,7 @@ class Rule(SqObject):
             log.debug("Guessing rule '%s' language from repo '%s'", self.key, str(data.get("repo", "")))
             self.language = EXTERNAL_REPOS.get(data.get("repo", ""), "UNKNOWN")
         self.template_key = data.get("templateKey")
-        self.description = data.get("mdDesc")
+        self.description = _build_description(data)
         self.custom_desc = data.get("mdDesc" if self.template_key else "mdNote")
         self.created_at = data["createdAt"]
         self.is_template = data.get("isTemplate", False)


### PR DESCRIPTION
## Summary

Fixes #2109.

Recent SonarQube versions return the rule description in a `descriptionSections` array of `{key, content}` entries instead of the legacy `description` HTML string. `Rule.__init__` was assigning `data.get("mdDesc")` (the markdown source) to `self.description`, so on those versions the HTML description ended up being either wrong-format or empty.

## Change

Add a module-level helper `_build_description()` in `sonar/rules.py` that implements the three rules from the issue:

1. If `descriptionSections` has a single entry with `key == "default"`, the description is just that entry's `content`.
2. If `descriptionSections` has multiple entries, the description is the concatenation of `<h1>{key}</h1>{content}` for each section — matching what the SonarQube UI renders.
3. Otherwise, fall back to the legacy `description` field.

`Rule.__init__` now uses this helper to populate `self.description`.

`self.custom_desc` is unchanged — it reads `mdDesc` / `mdNote` for the user's editable markdown note (used by `Rule.set_description()` to extend a rule with a custom note), which is independent of the structural API change.

## Verification

The helper was unit-tested inline against four cases:

| Input | Output |
|---|---|
| `{"descriptionSections": [{"key": "default", "content": "just content"}]}` | `"just content"` |
| `{"descriptionSections": [{"key": "intro", "content": "A"}, {"key": "why", "content": "B"}]}` | `"<h1>intro</h1>A<h1>why</h1>B"` |
| `{"description": "legacy html"}` | `"legacy html"` |
| `{}` | `None` |

## Test plan

- [ ] `sonar-rules --csv -u <SQ 2025.x> ...` produces rules whose `description` is real HTML, not markdown
- [ ] `sonar-rules` against an older SQ (9.9) that only returns `description` still populates `description`
- [ ] No regression: `Rule.set_description(...)` / `reset_description()` still work — they use `custom_desc`, not `description`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
