### PR TITLE
Declare organization on org-scoped SQC write endpoints (follow-up to #2395)

### DIFF
--- a/sonar/api/cloud.json
+++ b/sonar/api/cloud.json
@@ -378,6 +378,7 @@
             "method": "POST",
             "api": "api/qualitygates/create",
             "params": [
+                "organization",
                 "name"
             ]
         },
@@ -394,6 +395,7 @@
             "method": "POST",
             "api": "api/qualitygates/destroy",
             "params": [
+                "organization",
                 "id"
             ]
         },
@@ -409,6 +411,7 @@
             "method": "POST",
             "api": "api/qualitygates/rename",
             "params": [
+                "organization",
                 "id",
                 "name"
             ]
@@ -430,6 +433,7 @@
             "method": "POST",
             "api": "api/qualitygates/create_condition",
             "params": [
+                "organization",
                 "gateId",
                 "metric",
                 "op",
@@ -440,6 +444,7 @@
             "method": "POST",
             "api": "api/qualitygates/delete_condition",
             "params": [
+                "organization",
                 "id"
             ]
         }
@@ -457,6 +462,7 @@
             "method": "POST",
             "api": "api/alm_settings/delete",
             "params": [
+                "organization",
                 "key"
             ]
         },
@@ -464,6 +470,7 @@
             "method": "POST",
             "api": "api/alm_settings/create_github",
             "params": [
+                "organization",
                 "key",
                 "url",
                 "appId",
@@ -476,6 +483,7 @@
             "method": "POST",
             "api": "api/alm_settings/create_gitlab",
             "params": [
+                "organization",
                 "key",
                 "url",
                 "personalAccessToken"
@@ -485,6 +493,7 @@
             "method": "POST",
             "api": "api/alm_settings/create_azure",
             "params": [
+                "organization",
                 "key",
                 "url",
                 "personalAccessToken"
@@ -494,6 +503,7 @@
             "method": "POST",
             "api": "api/alm_settings/create_bitbucket",
             "params": [
+                "organization",
                 "key",
                 "url",
                 "personalAccessToken"
@@ -503,6 +513,7 @@
             "method": "POST",
             "api": "api/alm_settings/create_bitbucketcloud",
             "params": [
+                "organization",
                 "key",
                 "workspace",
                 "clientId",
@@ -513,6 +524,7 @@
             "method": "POST",
             "api": "api/alm_settings/update_github",
             "params": [
+                "organization",
                 "key",
                 "url",
                 "clientId",
@@ -525,6 +537,7 @@
             "method": "POST",
             "api": "api/alm_settings/update_gitlab",
             "params": [
+                "organization",
                 "key",
                 "url",
                 "personalAccessToken"
@@ -534,6 +547,7 @@
             "method": "POST",
             "api": "api/alm_settings/update_azure",
             "params": [
+                "organization",
                 "key",
                 "url",
                 "personalAccessToken"
@@ -543,6 +557,7 @@
             "method": "POST",
             "api": "api/alm_settings/update_bitbucket",
             "params": [
+                "organization",
                 "key",
                 "url",
                 "personalAccessToken"
@@ -552,6 +567,7 @@
             "method": "POST",
             "api": "api/alm_settings/update_bitbucketcloud",
             "params": [
+                "organization",
                 "key",
                 "workspace",
                 "clientId",
@@ -562,6 +578,7 @@
             "method": "POST",
             "api": "api/alm_integrations/set_pat",
             "params": [
+                "organization",
                 "almSettings",
                 "pat",
                 "username"
@@ -737,6 +754,7 @@
             "method": "POST",
             "api": "api/webhooks/create",
             "params": [
+                "organization",
                 "name",
                 "url",
                 "secret",
@@ -756,6 +774,7 @@
             "method": "POST",
             "api": "api/webhooks/update",
             "params": [
+                "organization",
                 "webhook",
                 "name",
                 "url",
@@ -766,6 +785,7 @@
             "method": "POST",
             "api": "api/webhooks/delete",
             "params": [
+                "organization",
                 "webhook"
             ]
         },
@@ -784,6 +804,7 @@
             "method": "POST",
             "api": "api/qualityprofiles/create",
             "params": [
+                "organization",
                 "name",
                 "language"
             ]
@@ -802,6 +823,7 @@
             "method": "POST",
             "api": "api/qualityprofiles/delete",
             "params": [
+                "organization",
                 "qualityProfile",
                 "language"
             ]
@@ -825,6 +847,7 @@
             "method": "POST",
             "api": "api/qualityprofiles/rename",
             "params": [
+                "organization",
                 "id",
                 "name"
             ]
@@ -833,6 +856,7 @@
             "method": "POST",
             "api": "api/qualityprofiles/copy",
             "params": [
+                "organization",
                 "toName",
                 "fromKey"
             ]
@@ -841,6 +865,7 @@
             "method": "POST",
             "api": "api/qualityprofiles/change_parent",
             "params": [
+                "organization",
                 "qualityProfile",
                 "language",
                 "parentQualityProfile"
@@ -850,6 +875,7 @@
             "method": "POST",
             "api": "api/qualityprofiles/set_default",
             "params": [
+                "organization",
                 "qualityProfile",
                 "language"
             ]
@@ -858,6 +884,7 @@
             "method": "POST",
             "api": "api/qualityprofiles/activate_rule",
             "params": [
+                "organization",
                 "key",
                 "rule",
                 "prioritizedRule",
@@ -870,6 +897,7 @@
             "method": "POST",
             "api": "api/qualityprofiles/deactivate_rule",
             "params": [
+                "organization",
                 "key",
                 "rule"
             ]
@@ -1007,6 +1035,7 @@
             "method": "POST",
             "api": "api/settings/set",
             "params": [
+                "organization",
                 "key",
                 "value",
                 "values",
@@ -1030,6 +1059,7 @@
             "method": "POST",
             "api": "api/settings/set",
             "params": [
+                "organization",
                 "key",
                 "value",
                 "values",
@@ -1068,6 +1098,7 @@
             "method": "POST",
             "api": "api/new_code_periods/set",
             "params": [
+                "organization",
                 "type",
                 "value",
                 "project",
@@ -1089,6 +1120,7 @@
             "method": "POST",
             "api": "api/settings/reset",
             "params": [
+                "organization",
                 "keys",
                 "component"
             ]


### PR DESCRIPTION
## Summary

Follow-up to #2395 / PR #2415.

#2415 declared `organization` on org-scoped **read** endpoints in `cloud.json`, but the scope explicitly excluded writes. As soon as `sonar-config import` hits any org-scoped write on SonarQube Cloud, the same `400 The 'organization' parameter is missing` returns. Real-world hit just now:

```
2026-06-08 13:17:26 | ERROR | URL https://sonarcloud.io/api/webhooks/create?...
                              HTTP error 400 - : The 'organization' parameter is missing (POST request)
```

This PR closes the gap by adding `"organization"` to the `params` list of every org-scoped write op in the same classes covered by #2415.

## Endpoints fixed (32 total)

| Class | Operations |
|---|---|
| `QualityProfile` | `CREATE`, `DELETE`, `RENAME`, `COPY`, `CHANGE_PARENT`, `SET_DEFAULT`, `ACTIVATE_RULE`, `DEACTIVATE_RULE` |
| `WebHook` | `CREATE`, `UPDATE`, `DELETE` |
| `QualityGate` | `CREATE`, `DELETE`, `RENAME`, `CREATE_CONDITION`, `DELETE_CONDITION` |
| `Setting` | `CREATE`, `UPDATE`, `SET_NEW_CODE_PERIOD`, `RESET` |
| `DevopsPlatform` | `DELETE`, `CREATE_GITHUB`, `CREATE_GITLAB`, `CREATE_AZURE`, `CREATE_BITBUCKET`, `CREATE_BITBUCKETCLOUD`, `UPDATE_GITHUB`, `UPDATE_GITLAB`, `UPDATE_AZURE`, `UPDATE_BITBUCKET`, `UPDATE_BITBUCKETCLOUD`, `SET_PAT` |

Component-scoped writes (e.g. `api/issues/set_severity`, `api/project_branches/*`, `api/issues/assign`) are unchanged — the component/issue key carries the org context server-side.

## Test plan

- [ ] `sonar-config -i <config.json> ...` on SQC creates a webhook (the failure from the report) without the 400
- [ ] `sonar-config -i ...` activates a rule in a quality profile, creates a quality gate condition, and sets an ALM binding without organization-missing errors
- [ ] SQS test matrices (`latest`, `cb`, `99`) still pass — adding an extra param to the SQC spec doesn't touch the SQS specs

🤖 Generated with [Claude Code](https://claude.com/claude-code)
