### PR TITLE
workaround when JSON branch name is like a float : add function _fix_float_names

### DIFF
--- a/sonar/util/misc.py
+++ b/sonar/util/misc.py
@@ -113,9 +113,25 @@ def sort_lists(data: Any) -> Any:
     return data
 
 
+def fix_float_names(data: Any) -> None:
+    """Recursively fix float names to strings"""
+    if isinstance(data, list):
+        for item in data:
+            if isinstance(item, dict):
+                if "name" in item and isinstance(item["name"], (int, float)):
+                    item["name"] = str(item["name"])
+                fix_float_names(item)
+    elif isinstance(data, dict):
+        for v in data.values():
+            if isinstance(v, dict) and "name" in v and isinstance(v["name"], (int, float)):
+                v["name"] = str(v["name"])
+            fix_float_names(v)
+
+
 def json_dump(jsondata: Union[list[str], dict[str, str]], indent: int = 3, sort_keys: bool = False) -> str:
     """JSON dump helper"""
     newdata = sort_lists(deepcopy(jsondata))
+    fix_float_names(newdata)
     return json.dumps(newdata, indent=indent, sort_keys=sort_keys, separators=(",", ": "))
 
 


### PR DESCRIPTION
closes https://github.com/okorach/sonar-tools/issues/2422 

I propose this workaround to resolve this issue specifically.

I don't know if this will resolve all cases, because I've observed that the branch name coming from the SonarQube API is indeed a string and is likely converted to a float during processing by `sonar-config --export`, perhaps by using this code: https://github.com/okorach/sonar-tools/pull/2181/changes#diff-c8fc48746a4c2a24643d2a3407bb34fe415ae20721a6b34764fd91be6f9d1e8bR39