### PR TITLE
Fix #2426: bump base image to alpine 3.24.1

### DIFF
--- a/conf/release.Dockerfile
+++ b/conf/release.Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.23.4
+FROM alpine:3.24.1
 LABEL maintainer="olivier.korach@gmail.com" 
 ENV IN_DOCKER="Yes"
 

--- a/conf/snapshot.Dockerfile
+++ b/conf/snapshot.Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.23.4
+FROM alpine:3.24.1
 LABEL maintainer="olivier.korach@gmail.com" 
 ENV IN_DOCKER="Yes"
 

--- a/migration/release.Dockerfile
+++ b/migration/release.Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.23.4
+FROM alpine:3.24.1
 LABEL maintainer="olivier.korach@gmail.com" 
 ENV IN_DOCKER="Yes"
 

--- a/migration/snapshot.Dockerfile
+++ b/migration/snapshot.Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.23.4
+FROM alpine:3.24.1
 LABEL maintainer="olivier.korach@gmail.com" 
 ENV IN_DOCKER="Yes"
 


### PR DESCRIPTION
Bumps the base Docker image from `alpine:3.23.4` to `alpine:3.24.1` across all four Dockerfiles:

- `conf/release.Dockerfile`
- `conf/snapshot.Dockerfile`
- `migration/release.Dockerfile`
- `migration/snapshot.Dockerfile`

Fixes #2426

🤖 Generated with [Claude Code](https://claude.com/claude-code)