### PR TITLE
Fix #2422: keep branch name as string in sonar-config export

### DIFF
--- a/sonar/util/misc.py
+++ b/sonar/util/misc.py
@@ -89,8 +89,9 @@ def clean_data(d: Any, remove_empty: bool = True, remove_none: bool = True) -> A
     if remove_empty:
         d = {k: v for k, v in d.items() if not isinstance(v, (str, list, dict, tuple, set)) or len(v) != 0}
 
-    # Recurse
-    return {k: clean_data(v, remove_empty, remove_none) if k not in ("key", "pattern") else v for k, v in d.items()}
+    # Recurse - "key", "name" and "pattern" values are identifiers and must never be type-coerced
+    # (e.g. a branch named "1.203" must stay the string "1.203", not become the float 1.203)
+    return {k: clean_data(v, remove_empty, remove_none) if k not in ("key", "name", "pattern") else v for k, v in d.items()}
 
 
 def remove_nones(d: Any) -> Any:

--- a/test/unit/test_utilities.py
+++ b/test/unit/test_utilities.py
@@ -206,6 +206,18 @@ def test_clean_data() -> None:
     assert res == {"a": {"3": "foo"}, "b": [5, "bar"], "c": 5}
 
 
+def test_clean_data_identifiers_not_coerced() -> None:
+    """Identifier fields (key, name, pattern) must keep their string type even when they look numeric (issue #2422)"""
+    branches = [{"name": "1.203", "keepWhenInactive": True}, {"name": "master", "isMain": True}]
+    res = util.clean_data(branches, remove_none=True, remove_empty=True)
+    assert res == [{"name": "1.203", "keepWhenInactive": True}, {"name": "master", "isMain": True}]
+    assert all(isinstance(b["name"], str) for b in res)
+
+    d = {"key": "1.2", "name": "3.4", "pattern": "5.6", "value": "7.8"}
+    res = util.clean_data(d, remove_none=True, remove_empty=True)
+    assert res == {"key": "1.2", "name": "3.4", "pattern": "5.6", "value": 7.8}
+
+
 def test_sort_lists() -> None:
     """test_sort_lists"""
     d = {"c": [3, 1, 2], "b": {"y": [5, 4], "x": "foo"}, "a": "bar"}


### PR DESCRIPTION
## Problem

`sonar-config --export` produced JSON where a branch whose name looks like a number (e.g. `1.203`) was written as a JSON **number** instead of a string:

```json
"branches": [
  { "name": "master", "isMain": true },
  { "name": 1.203 }
]
```

Re-importing such a file fails schema validation:

```
-> Error occured at: projects[com.myproject:name].branches[1.203].name -> 1.203 is not of type 'string'
```

## Root cause

`clean_data()` (in `sonar/util/misc.py`), called on the write path of the config export, recursively type-coerces every string value via `convert_string()` — turning `"1.203"` into the float `1.203`. Only the `key` and `pattern` fields were exempt from this coercion; `name` was not.

## Fix

Exempt the `name` identifier field from type coercion in `clean_data()`, alongside the existing `key` and `pattern` exemptions. Branch (and other object) names now always serialize as strings, even when they look numeric.

## Test

Added `test_clean_data_identifiers_not_coerced` asserting that `key`, `name`, and `pattern` values keep their string type while other values (e.g. `value`) are still coerced as before.

Fixes #2422

🤖 Generated with [Claude Code](https://claude.com/claude-code)