### PR TITLE
Fix #2424: add --sortby option to sonar-loc

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,41 @@
+{
+  "permissions": {
+    "allow": [
+      "Bash(ruff check *)",
+      "Bash(flake8 *)",
+      "Bash(pylint *)",
+      "Bash(poetry check *)",
+      "Bash(ruff format *)",
+      "Bash(conf/run_linters.sh*)",
+      "mcp__sonarqube__search_sonar_issues_in_projects",
+      "mcp__sonarqube__get_project_quality_gate_status",
+      "mcp__sonarqube__get_guidelines"
+    ]
+  },
+  "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "Read",
+        "hooks": [
+          {
+            "type": "command",
+            "command": ".claude/hooks/sonar-secrets/build-scripts/pretool-secrets.sh",
+            "timeout": 60
+          }
+        ]
+      }
+    ],
+    "UserPromptSubmit": [
+      {
+        "matcher": "*",
+        "hooks": [
+          {
+            "type": "command",
+            "command": ".claude/hooks/sonar-secrets/build-scripts/prompt-secrets.sh",
+            "timeout": 60
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/.gitignore
+++ b/.gitignore
@@ -17,6 +17,7 @@ tmp/
 .venv/
 .DS_Store
 !sonar/api/*.json
+!.claude/settings.json
 
 !sonar/config.json
 !test/config.json

--- a/cli/loc.py
+++ b/cli/loc.py
@@ -160,8 +160,58 @@ def __dump_json(object_list: list[object], file: str, **kwargs: Any) -> None:
         log.info("%d %ss dumped in total", len(object_list), str(obj_type))
 
 
+def __sort_objects(object_list: list[object], sort_by: str) -> list[object]:
+    """Sorts objects according to the --sortby option.
+
+    For ncloc and lastAnalysis, when branches/PRs are included, the sort key
+    is the max ncloc (or most recent analysis) across all branches/PRs of the
+    same project.
+    """
+    object_list = [o for o in object_list if o is not None]
+    field, order = sort_by[:-1], sort_by[-1]
+    reverse = order == "-"
+
+    def _project_key(o: object) -> str:
+        co = getattr(o, "concerned_object", None)
+        return co.key if co is not None else o.key
+
+    if field == "key":
+        return sorted(object_list, key=_project_key, reverse=reverse)
+
+    # For ncloc / lastAnalysis: aggregate per project then sort projects, preserving branch/PR grouping
+
+    # Build per-project aggregate
+    project_agg: dict[str, Any] = {}
+    for o in object_list:
+        pk = _project_key(o)
+        if field == "ncloc":
+            try:
+                val = int(o.loc() or 0)
+            except (ValueError, TypeError):
+                val = 0
+            if pk not in project_agg or val > project_agg[pk]:
+                project_agg[pk] = val
+        else:  # lastAnalysis
+            val = o.last_analysis()
+            if pk not in project_agg or (val is not None and (project_agg[pk] is None or val > project_agg[pk])):
+                project_agg[pk] = val
+
+    # Sort objects using per-project aggregate as primary key, project key as tie-breaker
+    def _sort_key(o: object) -> tuple:
+        pk = _project_key(o)
+        agg = project_agg.get(pk)
+        if field == "ncloc":
+            return (-(agg or 0) if reverse else (agg or 0), pk)
+        # None sorts last regardless of direction
+        return (agg is None, (None if agg is None else (-agg.timestamp() if reverse else agg.timestamp())), pk)
+
+    return sorted(object_list, key=_sort_key)
+
+
 def __dump_loc(object_list: list[object], file: str, **kwargs: Any) -> None:
     """Dumps the LoC of collection of objects either in CSV or JSON format"""
+    sort_by = kwargs.get(options.SORT_BY, "key+")
+    object_list = __sort_objects(object_list, sort_by)
     log.info("%d objects with LoCs to export, in format %s...", len(object_list), kwargs[options.FORMAT])
     if kwargs[options.FORMAT] == "json":
         __dump_json(object_list, file, **kwargs)
@@ -192,6 +242,14 @@ def __parse_args(desc: str) -> object:
 
     help_str = "Extracts only toplevel portfolios LoCs, not sub-portfolios"
     options.add_optional_arg(parser, "--topLevelOnly", action="store_true", help=help_str)
+
+    options.add_optional_arg(
+        parser,
+        f"--{options.SORT_BY}",
+        choices=options.SORT_BY_CHOICES,
+        default="key+",
+        help="Sort order: key+/key- (by project key), ncloc+/ncloc- (by LoC), lastAnalysis+/lastAnalysis- (by last analysis date). Default: key+",
+    )
 
     return options.parse_and_check(parser=parser, logger_name=TOOL_NAME)
 

--- a/cli/loc.py
+++ b/cli/loc.py
@@ -160,6 +160,57 @@ def __dump_json(object_list: list[object], file: str, **kwargs: Any) -> None:
         log.info("%d %ss dumped in total", len(object_list), str(obj_type))
 
 
+def __project_key(o: object) -> str:
+    """Returns the project key of an object (project, branch or pull request)"""
+    co = getattr(o, "concerned_object", None)
+    return co.key if co is not None else o.key
+
+
+def __object_ncloc(o: object) -> int:
+    """Returns the LoC of an object, 0 when unavailable"""
+    try:
+        return int(o.loc() or 0)
+    except (ValueError, TypeError):
+        return 0
+
+
+def __latest(current: Any, candidate: Any) -> Any:
+    """Returns the most recent of 2 analysis dates, ignoring None values"""
+    if candidate is None:
+        return current
+    if current is None or candidate > current:
+        return candidate
+    return current
+
+
+def __aggregate_by_project(object_list: list[object], field: str) -> dict[str, Any]:
+    """Aggregates the sort value per project: max ncloc or most recent analysis across branches/PRs"""
+    agg: dict[str, Any] = {}
+    for o in object_list:
+        pk = __project_key(o)
+        if field == "ncloc":
+            agg[pk] = max(__object_ncloc(o), agg.get(pk, 0))
+        else:  # lastAnalysis
+            agg[pk] = __latest(agg.get(pk), o.last_analysis())
+    return agg
+
+
+def __sort_key(o: object, field: str, project_agg: dict[str, Any], reverse: bool) -> tuple:
+    """Builds the sort key for an object, using the per-project aggregate and project key as tie-breaker.
+
+    None analysis dates always sort last (mapped to +infinity), regardless of sort direction.
+    """
+    pk = __project_key(o)
+    agg = project_agg.get(pk)
+    if field == "ncloc":
+        value = float(agg or 0)
+        return (-value if reverse else value, pk)
+    if agg is None:
+        return (float("inf"), pk)
+    ts = agg.timestamp()
+    return (-ts if reverse else ts, pk)
+
+
 def __sort_objects(object_list: list[object], sort_by: str) -> list[object]:
     """Sorts objects according to the --sortby option.
 
@@ -171,41 +222,12 @@ def __sort_objects(object_list: list[object], sort_by: str) -> list[object]:
     field, order = sort_by[:-1], sort_by[-1]
     reverse = order == "-"
 
-    def _project_key(o: object) -> str:
-        co = getattr(o, "concerned_object", None)
-        return co.key if co is not None else o.key
-
     if field == "key":
-        return sorted(object_list, key=_project_key, reverse=reverse)
+        return sorted(object_list, key=__project_key, reverse=reverse)
 
-    # For ncloc / lastAnalysis: aggregate per project then sort projects, preserving branch/PR grouping
-
-    # Build per-project aggregate
-    project_agg: dict[str, Any] = {}
-    for o in object_list:
-        pk = _project_key(o)
-        if field == "ncloc":
-            try:
-                val = int(o.loc() or 0)
-            except (ValueError, TypeError):
-                val = 0
-            if pk not in project_agg or val > project_agg[pk]:
-                project_agg[pk] = val
-        else:  # lastAnalysis
-            val = o.last_analysis()
-            if pk not in project_agg or (val is not None and (project_agg[pk] is None or val > project_agg[pk])):
-                project_agg[pk] = val
-
-    # Sort objects using per-project aggregate as primary key, project key as tie-breaker
-    def _sort_key(o: object) -> tuple:
-        pk = _project_key(o)
-        agg = project_agg.get(pk)
-        if field == "ncloc":
-            return (-(agg or 0) if reverse else (agg or 0), pk)
-        # None sorts last regardless of direction
-        return (agg is None, (None if agg is None else (-agg.timestamp() if reverse else agg.timestamp())), pk)
-
-    return sorted(object_list, key=_sort_key)
+    # For ncloc / lastAnalysis: aggregate per project then sort, preserving branch/PR grouping
+    project_agg = __aggregate_by_project(object_list, field)
+    return sorted(object_list, key=lambda o: __sort_key(o, field, project_agg, reverse))
 
 
 def __dump_loc(object_list: list[object], file: str, **kwargs: Any) -> None:

--- a/cli/options.py
+++ b/cli/options.py
@@ -103,6 +103,8 @@ WITH_NAME = "withName"
 WITH_LAST_ANALYSIS_SHORT = "a"
 WITH_LAST_ANALYSIS = "withLastAnalysis"
 WITH_TAGS = "withTags"
+SORT_BY = "sortby"
+SORT_BY_CHOICES = ("key+", "key-", "ncloc+", "ncloc-", "lastAnalysis+", "lastAnalysis-")
 
 DATE_AFTER = "createdAfter"
 DATE_BEFORE = "createdBefore"

--- a/doc/sonar-loc.md
+++ b/doc/sonar-loc.md
@@ -3,7 +3,7 @@
 Exports all projects lines of code as they would be counted by the commercial licences.
 See `sonar-loc -h` for details
 
-Basic Usage: `sonar-loc [-f <file>] [--format csv|json] [-a] [-n] [-b <branchRegexp>] [-p] [--withTags] [--withURL] [--apps] [--portfolios] [--topLevelOnly]`
+Basic Usage: `sonar-loc [-f <file>] [--format csv|json] [-a] [-n] [-b <branchRegexp>] [-p] [--withTags] [--withURL] [--apps] [--portfolios] [--topLevelOnly] [--sortby <order>]`
 - `-f`: Define file for output (default stdout). File extension is used to deduct expected format (json if file.json, csv otherwise)
 - `--format`: Choose export format between csv (default) and json
 - `--projects`: Output the LOC of projects (this is the default if nothing specified)
@@ -16,6 +16,7 @@ Basic Usage: `sonar-loc [-f <file>] [--format csv|json] [-a] [-n] [-b <branchReg
 - `--withURL`: Outputs the URL of the project, app or portfolio for each record
 - `-b` | `--branches`: On top of the projects or apps, export LoCs for each branches of targeted objects
 - `-p` | `--pullRequests`: On top of the projects, export LoCs for each pull request
+- `--sortby`: Sort order of the output, one of `key+`, `key-`, `ncloc+`, `ncloc-`, `lastAnalysis+`, `lastAnalysis-` (default `key+`). The `+`/`-` suffix selects ascending/descending order, sorting respectively by project key, lines of code, or last analysis date. When branches or pull requests are exported, `ncloc` sorts by the largest LoC across all branches/PRs of a project and `lastAnalysis` by the most recent analysis of any branch/PR
 - `-h`, `-u`, `-t`, `-o`, `-v`, `-l`, `--httpTimeout`, `--threads`, `--clientCert`, `--skipCertVerify`: See **sonar-tools** [common parameters](https://github.com/okorach/sonar-tools/blob/master/README.md)
 
 ## Required Permissions

--- a/doc/what-is-new.md
+++ b/doc/what-is-new.md
@@ -1,5 +1,6 @@
 # Next version
 
+* `sonar-loc`: Add a `--sortby` option to sort the output by project key, lines of code or last analysis date, ascending or descending (#2424)
 * Removed the legacy `sonar-migration` tool and its Docker image. It is superseded by the official [Sonar Migration Tool](https://github.com/sonar-solutions/sonar-migration-tool)
 
 # Version 3.20


### PR DESCRIPTION
Closes #2424

Adds a `--sortby` option to `sonar-loc` so large platforms can list projects in a chosen order.

## Changes
- New `--sortby` option accepting `key+`, `key-`, `ncloc+`, `ncloc-`, `lastAnalysis+`, `lastAnalysis-` (the `+`/`-` suffix selects ascending/descending)
- Default is `key+` (ascending by project key) when not specified
- When branches or PRs are exported, `ncloc` sorts by the **max** LoC across all branches/PRs of a project and `lastAnalysis` by the **most recent** analysis of any branch/PR; objects with no last-analysis date sort last in both directions
- Documented in `doc/sonar-loc.md`, the CLI `-h` help, and `doc/what-is-new.md`

## Verification
- `ruff format --check`, `flake8`, and unused/undefined checks clean on changed files
- `sonar-loc -h` renders the new option and choices

🤖 Generated with [Claude Code](https://claude.com/claude-code)