### PR TITLE
Fix trivy2sonar KeyError when a result has no Vulnerabilities

### DIFF
--- a/conf/trivy2sonar.py
+++ b/conf/trivy2sonar.py
@@ -37,47 +37,48 @@ def main() -> None:
     rules_dict = {}
     issue_list = {}
 
-    for issue in json.loads(text)["Results"][0]["Vulnerabilities"]:
-        sonar_issue = {
-            "ruleId": f"{TOOLNAME}:{issue['VulnerabilityID']}",
-            "effortMinutes": 30,
-            "primaryLocation": {
-                "message": f"{issue['VulnerabilityID']} - {issue['Title']}",
-                "filePath": "conf/snapshot.Dockerfile",
-                "textRange": {
-                    "startLine": 1,
-                    # "endLine": 1,
-                    # "startColumn": 1,
-                    # "endColumn": 1,
+    for result in json.loads(text).get("Results", []):
+        for issue in result.get("Vulnerabilities", []):
+            sonar_issue = {
+                "ruleId": f"{TOOLNAME}:{issue['VulnerabilityID']}",
+                "effortMinutes": 30,
+                "primaryLocation": {
+                    "message": f"{issue['VulnerabilityID']} - {issue['Title']}",
+                    "filePath": "conf/snapshot.Dockerfile",
+                    "textRange": {
+                        "startLine": 1,
+                        # "endLine": 1,
+                        # "startColumn": 1,
+                        # "endColumn": 1,
+                    },
                 },
-            },
-        }
-        # score = max([v["V3Score"] for v in issue['CVSS'].values()])
-        # if score <= 4:
-        #     sev = "LOW"
-        # elif score <= 7:
-        #     sev = "MEDIUM"
-        # else:
-        #     sev = "HIGH"
-        sev_mqr = issue.get("Severity", "MEDIUM")
-        sev_mqr = TRIVY_TO_MQR_MAPPING.get(sev_mqr, sev_mqr)
-        if sev_mqr == "UNKNOWN":
-            sev_mqr = "MEDIUM"
-        rules_dict[f"{TOOLNAME}:{issue['VulnerabilityID']}"] = {
-            "id": f"{TOOLNAME}:{issue['VulnerabilityID']}",
-            "name": f"{TOOLNAME}:{issue['VulnerabilityID']} - {issue['Title']}",
-            "description": issue.get("Description", ""),
-            "engineId": TOOLNAME,
-            "type": "VULNERABILITY",
-            "severity": MAPPING.get(sev_mqr, sev_mqr),
-            "cleanCodeAttribute": "LOGICAL",
-            "impacts": [{"softwareQuality": "SECURITY", "severity": sev_mqr}],
-        }
-        if v1:
-            sonar_issue["engineId"] = TOOLNAME
-            sonar_issue["severity"] = MAPPING.get(sev_mqr, sev_mqr)
-            sonar_issue["type"] = "VULNERABILITY"
-        issue_list[sonar_issue["primaryLocation"]["message"]] = sonar_issue
+            }
+            # score = max([v["V3Score"] for v in issue['CVSS'].values()])
+            # if score <= 4:
+            #     sev = "LOW"
+            # elif score <= 7:
+            #     sev = "MEDIUM"
+            # else:
+            #     sev = "HIGH"
+            sev_mqr = issue.get("Severity", "MEDIUM")
+            sev_mqr = TRIVY_TO_MQR_MAPPING.get(sev_mqr, sev_mqr)
+            if sev_mqr == "UNKNOWN":
+                sev_mqr = "MEDIUM"
+            rules_dict[f"{TOOLNAME}:{issue['VulnerabilityID']}"] = {
+                "id": f"{TOOLNAME}:{issue['VulnerabilityID']}",
+                "name": f"{TOOLNAME}:{issue['VulnerabilityID']} - {issue['Title']}",
+                "description": issue.get("Description", ""),
+                "engineId": TOOLNAME,
+                "type": "VULNERABILITY",
+                "severity": MAPPING.get(sev_mqr, sev_mqr),
+                "cleanCodeAttribute": "LOGICAL",
+                "impacts": [{"softwareQuality": "SECURITY", "severity": sev_mqr}],
+            }
+            if v1:
+                sonar_issue["engineId"] = TOOLNAME
+                sonar_issue["severity"] = MAPPING.get(sev_mqr, sev_mqr)
+                sonar_issue["type"] = "VULNERABILITY"
+            issue_list[sonar_issue["primaryLocation"]["message"]] = sonar_issue
 
     if len(issue_list) == 0:
         return


### PR DESCRIPTION
## Summary
- Fix `KeyError: 'Vulnerabilities'` crash when a Trivy result entry has no vulnerabilities (Trivy omits the key rather than providing an empty list)
- Iterate over all `Results` entries instead of only `Results[0]` so vulnerabilities from every scan target are captured

## Test plan
- [ ] Run trivy2sonar with a Trivy JSON report where at least one result entry has no vulnerabilities — should complete without error and produce correct output
- [ ] Run with a normal report containing vulnerabilities — output unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)