### PR TITLE
Fix ruff import sorting and ruff2sonar.py bugs

### DIFF
--- a/cli/cust_measures.py
+++ b/cli/cust_measures.py
@@ -24,9 +24,9 @@ Update a custom measure value:
     Usage: cust_measures.py -t <SQ_TOKEN> -u <SQ_URL> -k <projectKey> -m <metricKey> --updateValue <value>
 """
 
-from sonar import errcodes
-import sonar.util.misc as util
 import sonar.util.common_helper as chelp
+import sonar.util.misc as util
+from sonar import errcodes
 
 TOOL_NAME = "sonar-custom-measures"
 

--- a/cli/findings_export.py
+++ b/cli/findings_export.py
@@ -24,41 +24,39 @@ Usage: sonar-findings-export.py -t <SQ_TOKEN> -u <SQ_URL> [<filters>]
 """
 
 from __future__ import annotations
-from typing import Union, TextIO, TYPE_CHECKING
 
-import os
-import csv
 import concurrent.futures
+import csv
+import os
 import traceback
+from typing import TYPE_CHECKING, TextIO, Union
 
-from cli import options
 import sonar.logging as log
-from sonar import platform, exceptions, errcodes, version
-from sonar import hotspots, findings
-from sonar import dependency_risks
-from sonar.dependency_risks import DependencyRisk
-from sonar.util import issue_defs as idefs, types, component_helper
+import sonar.util.common_helper as chelp
 import sonar.util.constants as c
-
 import sonar.util.misc as util
 import sonar.utilities as sutil
-
-import sonar.util.common_helper as chelp
+from cli import options
+from sonar import dependency_risks, errcodes, exceptions, findings, hotspots, platform, version
 from sonar.applications import Application
+from sonar.dependency_risks import DependencyRisk
+from sonar.issues import TooManyFacetsError
 from sonar.portfolios import Portfolio
 from sonar.rules import Rule
-from sonar.issues import TooManyFacetsError
+from sonar.util import component_helper, types
+from sonar.util import issue_defs as idefs
 
 if TYPE_CHECKING:
-    from sonar.util.types import ConfigSettings
     from argparse import Namespace
-    from sonar.projects import Project
-    from sonar.components import Component
-    from sonar.branches import Branch
-    from sonar.pull_requests import PullRequest
-    from sonar.issues import Issue
-    from sonar.hotspots import Hotspot
+
     from sonar.app_branches import ApplicationBranch
+    from sonar.branches import Branch
+    from sonar.components import Component
+    from sonar.hotspots import Hotspot
+    from sonar.issues import Issue
+    from sonar.projects import Project
+    from sonar.pull_requests import PullRequest
+    from sonar.util.types import ConfigSettings
 
     ConcernedObject = Union[Project, Branch, PullRequest, Application, Portfolio, ApplicationBranch]
     Finding = Union[Issue, Hotspot]

--- a/cli/findings_sync.py
+++ b/cli/findings_sync.py
@@ -28,19 +28,18 @@ Only issues with a 100% match are synchronized. When there's a doubt, nothing is
 """
 
 import datetime
-from typing import Optional, Union, Any
+from typing import Any, Optional, Union
 
-from cli import options
 import sonar.logging as log
-from sonar.platform import Platform
-from sonar import syncer, exceptions, projects, branches, version
+import sonar.util.common_helper as chelp
 import sonar.util.misc as util
 import sonar.utilities as sutil
-import sonar.util.common_helper as chelp
-from sonar.issues import TooManyFacetsError
-
-from sonar.projects import Project
+from cli import options
+from sonar import branches, exceptions, projects, syncer, version
 from sonar.branches import Branch
+from sonar.issues import TooManyFacetsError
+from sonar.platform import Platform
+from sonar.projects import Project
 
 ProjectOrBranch = Union[Project, Branch]
 

--- a/cli/housekeeper.py
+++ b/cli/housekeeper.py
@@ -25,15 +25,16 @@ Currently:
 """
 
 from requests import RequestException
-from cli import options
-import sonar.logging as log
-from sonar import platform, tokens, users, projects, branches, pull_requests, version, errcodes
-import sonar.util.constants as c
-import sonar.utilities as sutil
-import sonar.util.misc as util
+
 import sonar.exceptions as ex
-from sonar.audit import problem
+import sonar.logging as log
 import sonar.util.common_helper as chelp
+import sonar.util.constants as c
+import sonar.util.misc as util
+import sonar.utilities as sutil
+from cli import options
+from sonar import branches, errcodes, platform, projects, pull_requests, tokens, users, version
+from sonar.audit import problem
 
 TOOL_NAME = "sonar-housekeeper"
 PROJ_MAX_AGE = "audit.projects.maxLastAnalysisAge"

--- a/cli/loc.py
+++ b/cli/loc.py
@@ -20,19 +20,20 @@
 #
 """Exports LoC per projects"""
 
-from typing import Any
 import csv
 import datetime
+from typing import Any
+
 from requests import RequestException
 
-from cli import options
 import sonar.logging as log
-from sonar import platform, portfolios, applications, projects, errcodes, exceptions, version
-import sonar.utilities as sutil
-import sonar.util.misc as util
-import sonar.util.constants as c
-from sonar.util import component_helper
 import sonar.util.common_helper as chelp
+import sonar.util.constants as c
+import sonar.util.misc as util
+import sonar.utilities as sutil
+from cli import options
+from sonar import applications, errcodes, exceptions, platform, portfolios, projects, version
+from sonar.util import component_helper
 
 TOOL_NAME = "sonar-loc"
 

--- a/cli/measures_export.py
+++ b/cli/measures_export.py
@@ -25,17 +25,17 @@
 """
 
 import csv
+
 from requests import RequestException
 
-from sonar.util import types
-from cli import options
 import sonar.logging as log
-from sonar import metrics, platform, exceptions, errcodes, version, measures, dependency_risks
-import sonar.utilities as sutil
-import sonar.util.misc as util
-import sonar.util.constants as c
-from sonar.util import component_helper
 import sonar.util.common_helper as chelp
+import sonar.util.constants as c
+import sonar.util.misc as util
+import sonar.utilities as sutil
+from cli import options
+from sonar import dependency_risks, errcodes, exceptions, measures, metrics, platform, version
+from sonar.util import component_helper, types
 
 TOOL_NAME = "sonar-measures"
 

--- a/cli/options.py
+++ b/cli/options.py
@@ -20,15 +20,15 @@
 """Cmd line options"""
 
 import os
-import sys
 import random
+import sys
 from argparse import ArgumentParser
-from typing import Optional, Any
+from typing import Any, Optional
 
 import sonar.logging as log
-from sonar import errcodes, version, exceptions
 import sonar.util.misc as util
 import sonar.utilities as sutil
+from sonar import errcodes, exceptions, version
 
 # Command line options
 

--- a/cli/projects_cli.py
+++ b/cli/projects_cli.py
@@ -21,18 +21,18 @@
 """Exports/Imports all projects of a SonarQube Server platform"""
 
 from __future__ import annotations
-from typing import Any
+
 import json
+from typing import Any
 
 from requests import RequestException
 
-from cli import options
 import sonar.logging as log
-from sonar import errcodes, exceptions, version
+import sonar.util.common_helper as chelp
 import sonar.util.misc as util
 import sonar.utilities as sutil
-from sonar import projects
-import sonar.util.common_helper as chelp
+from cli import options
+from sonar import errcodes, exceptions, projects, version
 from sonar.platform import Platform
 
 TOOL_NAME = "sonar-projects"

--- a/cli/projects_export.py
+++ b/cli/projects_export.py
@@ -23,8 +23,8 @@
 import sys
 from unittest.mock import patch
 
-from cli import options, projects_cli
 import sonar.logging as log
+from cli import options, projects_cli
 
 
 def main() -> None:

--- a/cli/projects_import.py
+++ b/cli/projects_import.py
@@ -23,8 +23,8 @@
 import sys
 from unittest.mock import patch
 
-from cli import options, projects_cli
 import sonar.logging as log
+from cli import options, projects_cli
 
 
 def main() -> None:

--- a/cli/rules_cli.py
+++ b/cli/rules_cli.py
@@ -22,12 +22,12 @@
 
 import csv
 
-from cli import options
 import sonar.logging as log
-from sonar import rules, platform, exceptions, errcodes, version, qualityprofiles
-import sonar.utilities as sutil
-import sonar.util.misc as util
 import sonar.util.common_helper as chelp
+import sonar.util.misc as util
+import sonar.utilities as sutil
+from cli import options
+from sonar import errcodes, exceptions, platform, qualityprofiles, rules, version
 
 TOOL_NAME = "sonar-rules"
 

--- a/cli/sonar_tools.py
+++ b/cli/sonar_tools.py
@@ -21,8 +21,8 @@
 
 """Main entry point for sonar-tools"""
 
-from sonar import version, errcodes
 import sonar.util.common_helper as chelp
+from sonar import errcodes, version
 
 
 def main() -> None:

--- a/cli/support.py
+++ b/cli/support.py
@@ -32,7 +32,7 @@ import sonar.logging as log
 import sonar.util.common_helper as chelp
 from cli import options
 from sonar import errcodes, sif
-from sonar.audit import audit_config, problem
+from sonar.audit import audit_config, problem  # pylint: disable=no-name-in-module
 from sonar.audit.severities import Severity
 
 PRIVATE_COMMENT = [{"key": "sd.public.comment", "value": {"internal": "true"}}]

--- a/cli/support.py
+++ b/cli/support.py
@@ -20,19 +20,20 @@
 #
 """Audits a SUPPORT ticket SIF"""
 
-from http import HTTPStatus
-import sys
-import os
-import json
 import argparse
+import json
+import os
+import sys
+from http import HTTPStatus
+
 import requests
 
-from cli import options
 import sonar.logging as log
-from sonar import sif, errcodes
-from sonar.audit import problem, audit_config
-from sonar.audit.severities import Severity
 import sonar.util.common_helper as chelp
+from cli import options
+from sonar import errcodes, sif
+from sonar.audit import audit_config, problem
+from sonar.audit.severities import Severity
 
 PRIVATE_COMMENT = [{"key": "sd.public.comment", "value": {"internal": "true"}}]
 

--- a/conf/offline/setup.py
+++ b/conf/offline/setup.py
@@ -21,8 +21,8 @@
 """Package setup"""
 
 import setuptools
-from sonar import version
 
+from sonar import version
 
 with open("README.md", encoding="utf-8") as fh:
     long_description = fh.read()

--- a/conf/ruff2sonar.py
+++ b/conf/ruff2sonar.py
@@ -58,6 +58,7 @@ def main() -> None:
             rule_id = m.group(4)
             message = m.group(6)
             sonar_issue = {
+                "engineId": TOOLNAME,
                 "ruleId": rule_id,
                 "effortMinutes": 5,
                 "primaryLocation": {
@@ -67,7 +68,6 @@ def main() -> None:
                 },
             }
             if v1:
-                sonar_issue["engineId"] = TOOLNAME
                 sonar_issue["severity"] = "MAJOR"
                 sonar_issue["type"] = "CODE_SMELL"
             rules_dict[rule_id] = {
@@ -106,6 +106,9 @@ def main() -> None:
         elif m := re.match(r"\s*(\d+)\s\|\s\|.*$", line):
             end_line = int(m.group(1))
         i += 1
+
+    if sonar_issue is not None:
+        issue_list.append(sonar_issue)
 
     if len(issue_list) == 0:
         return

--- a/conf/ruff2sonar.py
+++ b/conf/ruff2sonar.py
@@ -20,9 +20,9 @@
 #
 """Converts Ruff report format to Sonar external issues format"""
 
-import sys
-import re
 import json
+import re
+import sys
 
 TOOLNAME = "ruff"
 

--- a/conf/ruff2sonar.py
+++ b/conf/ruff2sonar.py
@@ -30,6 +30,20 @@ TRIVY_TO_MQR_MAPPING = {"CRITICAL": "BLOCKER"}
 MAPPING = {"LOW": "MINOR", "MEDIUM": "MAJOR", "HIGH": "CRITICAL", "BLOCKER": "BLOCKER"}
 
 
+def _apply_range_marker(issue_range: dict, rule_id: str, end_line: int | None, start_col: int | None, end_col: int | None) -> None:
+    """Update issue_range when a caret/underscore range marker line is parsed."""
+    issue_range["endLine"] = end_line or issue_range["startLine"]
+    if rule_id != "I001":
+        if start_col is not None:
+            issue_range["startColumn"] = start_col
+        if end_col is not None:
+            issue_range["endColumn"] = end_col
+    else:
+        issue_range["endLine"] -= 1
+        issue_range.pop("startColumn", None)
+        issue_range.pop("endColumn", None)
+
+
 def main() -> None:
     """Main script entry point"""
     v1 = len(sys.argv) > 1 and sys.argv[1] == "v1"
@@ -39,6 +53,7 @@ def main() -> None:
     i = 0
     sonar_issue = None
     issue_range = {}
+    rule_id = ""
     nblines = len(lines)
     end_line = None
     while i < nblines:
@@ -49,59 +64,21 @@ def main() -> None:
                 issue_list.append(sonar_issue)
                 end_line = None
             file_path = m.group(1)
-            issue_range = {
-                "startLine": int(m.group(2)),
-                "endLine": int(m.group(2)),
-                "startColumn": int(m.group(3)) - 1,
-                "endColumn": int(m.group(3)),
-            }
             rule_id = m.group(4)
             message = m.group(6)
-            sonar_issue = {
-                "engineId": TOOLNAME,
-                "ruleId": rule_id,
-                "effortMinutes": 5,
-                "primaryLocation": {
-                    "message": m.group(6),
-                    "filePath": file_path,
-                    "textRange": issue_range,
-                },
-            }
+            issue_range = {"startLine": int(m.group(2)), "endLine": int(m.group(2)), "startColumn": int(m.group(3)) - 1, "endColumn": int(m.group(3))}
+            sonar_issue = {"engineId": TOOLNAME, "ruleId": rule_id, "effortMinutes": 5, "primaryLocation": {"message": message, "filePath": file_path, "textRange": issue_range}}
             if v1:
                 sonar_issue["severity"] = "MAJOR"
                 sonar_issue["type"] = "CODE_SMELL"
-            rules_dict[rule_id] = {
-                "id": rule_id,
-                "name": rule_id,
-                "description": message,
-                "engineId": TOOLNAME,
-                "type": "CODE_SMELL",
-                "severity": "MAJOR",
-                "cleanCodeAttribute": "LOGICAL",
-                "impacts": [{"softwareQuality": "MAINTAINABILITY", "severity": "MEDIUM"}],
-            }
+            rules_dict[rule_id] = {"id": rule_id, "name": rule_id, "description": message, "engineId": TOOLNAME, "type": "CODE_SMELL", "severity": "MAJOR", "cleanCodeAttribute": "LOGICAL", "impacts": [{"softwareQuality": "MAINTAINABILITY", "severity": "MEDIUM"}]}
         elif m := re.match(r"\s+\|\s\|(_+)\^ [A-Z0-9]+", line):
-            # Search for pattern like "   |  |____^ B904" or "    |     ^^^^ RET505"
-            issue_range["endLine"] = end_line or issue_range["startLine"]
-            end_line = None
-            if rule_id != "I001":
-                issue_range["endColumn"] = len(m.group(1))
-            else:
-                issue_range["endLine"] -= 1
-                issue_range.pop("startColumn")
-                issue_range.pop("endColumn")
+            # Multi-line span closing marker: "   | |_____^ RUF012"
+            _apply_range_marker(issue_range, rule_id, end_line, None, len(m.group(1)))
             end_line = None
         elif m := re.match(r"\s+\| (\s+)(\^+) [A-Z0-9]+", line):
-            # Search for pattern like "    |     ^^^^ RET505"
-            issue_range["endLine"] = end_line or issue_range["startLine"]
-            end_line = None
-            if rule_id != "I001":
-                issue_range["startColumn"] = len(m.group(1))
-                issue_range["endColumn"] = issue_range["startColumn"] + len(m.group(2))
-            else:
-                issue_range["endLine"] -= 1
-                issue_range.pop("startColumn")
-                issue_range.pop("endColumn")
+            # Inline caret marker: "    |     ^^^^ RET505"
+            _apply_range_marker(issue_range, rule_id, end_line, len(m.group(1)), len(m.group(1)) + len(m.group(2)))
             end_line = None
         elif m := re.match(r"\s*(\d+)\s\|\s\|.*$", line):
             end_line = int(m.group(1))

--- a/conf/ruff2sonar.py
+++ b/conf/ruff2sonar.py
@@ -23,6 +23,7 @@
 import json
 import re
 import sys
+from typing import Optional
 
 TOOLNAME = "ruff"
 
@@ -30,7 +31,7 @@ TRIVY_TO_MQR_MAPPING = {"CRITICAL": "BLOCKER"}
 MAPPING = {"LOW": "MINOR", "MEDIUM": "MAJOR", "HIGH": "CRITICAL", "BLOCKER": "BLOCKER"}
 
 
-def _apply_range_marker(issue_range: dict, rule_id: str, end_line: int | None, start_col: int | None, end_col: int | None) -> None:
+def _apply_range_marker(issue_range: dict, rule_id: str, end_line: Optional[int], start_col: Optional[int], end_col: Optional[int]) -> None:
     """Update issue_range when a caret/underscore range marker line is parsed."""
     issue_range["endLine"] = end_line or issue_range["startLine"]
     if rule_id != "I001":

--- a/conf/ruff2sonar.py
+++ b/conf/ruff2sonar.py
@@ -22,6 +22,7 @@
 
 import sys
 import re
+import json
 
 TOOLNAME = "ruff"
 
@@ -79,7 +80,8 @@ def main() -> None:
                 "cleanCodeAttribute": "LOGICAL",
                 "impacts": [{"softwareQuality": "MAINTAINABILITY", "severity": "MEDIUM"}],
             }
-        elif m := re.match(r"\s+\|\s\|(_+)\^ [A-Z0-9]+", lines[i]):
+        elif m := re.match(r"\s+\|\s\|(_+)\^ [A-Z0-9]+", line):
+            # Search for pattern like "   |  |____^ B904" or "    |     ^^^^ RET505"
             issue_range["endLine"] = end_line or issue_range["startLine"]
             end_line = None
             if rule_id != "I001":
@@ -89,7 +91,19 @@ def main() -> None:
                 issue_range.pop("startColumn")
                 issue_range.pop("endColumn")
             end_line = None
-        elif m := re.match(r"\s*(\d+)\s\|\s\|.*$", lines[i]):
+        elif m := re.match(r"\s+\| (\s+)(\^+) [A-Z0-9]+", line):
+            # Search for pattern like "    |     ^^^^ RET505"
+            issue_range["endLine"] = end_line or issue_range["startLine"]
+            end_line = None
+            if rule_id != "I001":
+                issue_range["startColumn"] = len(m.group(1))
+                issue_range["endColumn"] = issue_range["startColumn"] + len(m.group(2))
+            else:
+                issue_range["endLine"] -= 1
+                issue_range.pop("startColumn")
+                issue_range.pop("endColumn")
+            end_line = None
+        elif m := re.match(r"\s*(\d+)\s\|\s\|.*$", line):
             end_line = int(m.group(1))
         i += 1
 
@@ -98,6 +112,7 @@ def main() -> None:
     external_issues = {"rules": list(rules_dict.values()), "issues": issue_list}
     if v1:
         external_issues.pop("rules")
+    print(json.dumps(external_issues, indent=3, separators=(",", ": ")))  # noqa: T201
 
 
 if __name__ == "__main__":

--- a/conf/shellcheck2sonar.py
+++ b/conf/shellcheck2sonar.py
@@ -20,8 +20,8 @@
 #
 """Converts shellcheck JSON format to Sonar external issues format"""
 
-import sys
 import json
+import sys
 
 TOOLNAME = "shellcheck"
 MAPPING = {"INFO": "INFO", "LOW": "MINOR", "MEDIUM": "MAJOR", "HIGH": "CRITICAL", "BLOCKER": "BLOCKER"}

--- a/conf/trivy2sonar.py
+++ b/conf/trivy2sonar.py
@@ -20,8 +20,8 @@
 #
 """Converts Trivy JSON format to Sonar external issues format"""
 
-import sys
 import json
+import sys
 
 TOOLNAME = "trivy"
 

--- a/sonar/aggregations.py
+++ b/sonar/aggregations.py
@@ -20,16 +20,15 @@
 """Parent module of applications and portfolios"""
 
 from __future__ import annotations
-from typing import Optional, Any, TYPE_CHECKING
-import json
 
-import sonar.logging as log
+import json
+from typing import TYPE_CHECKING, Any, Optional
 
 import sonar.components as comp
-from sonar import exceptions
-from sonar.audit.rules import get_rule
+import sonar.logging as log
+from sonar import exceptions, measures
 from sonar.audit.problem import Problem
-from sonar import measures
+from sonar.audit.rules import get_rule
 
 if TYPE_CHECKING:
     from sonar.platform import Platform

--- a/sonar/api/manager.py
+++ b/sonar/api/manager.py
@@ -21,19 +21,19 @@
 """SonarQube API manager"""
 
 from __future__ import annotations
-from typing import Any, Optional, ClassVar, TYPE_CHECKING
 
+import inspect
+import json
 import os
+from collections import defaultdict
 from enum import Enum
 from pathlib import Path
-import json
-from collections import defaultdict
-import inspect
+from typing import TYPE_CHECKING, Any, ClassVar, Optional
 
-import sonar.utilities as sutil
 import sonar.logging as log
-from sonar.util import misc
+import sonar.utilities as sutil
 from sonar.exceptions import UnsupportedOperation
+from sonar.util import misc
 
 if TYPE_CHECKING:
     from sonar.platform import Platform

--- a/sonar/app_branches.py
+++ b/sonar/app_branches.py
@@ -21,26 +21,26 @@
 """Abstraction of Sonar Application Branch"""
 
 from __future__ import annotations
-from typing import Optional, Union, Any, TYPE_CHECKING
+
 import json
+from typing import TYPE_CHECKING, Any, Optional, Union
+
 from requests.utils import quote
 
 import sonar.logging as log
+import sonar.util.constants as c
+import sonar.utilities as sutil
+from sonar import applications as apps
+from sonar import exceptions, measures
+from sonar.api.manager import ApiOperation as Oper
+from sonar.branches import Branch
+from sonar.components import Component
+from sonar.projects import Project
 from sonar.util import cache
 
-from sonar.components import Component
-from sonar.branches import Branch
-from sonar.projects import Project
-from sonar import exceptions
-import sonar.utilities as sutil
-from sonar.api.manager import ApiOperation as Oper
-import sonar.util.constants as c
-from sonar import applications as apps
-from sonar import measures
-
 if TYPE_CHECKING:
-    from sonar.issues import Issue
     from sonar.hotspots import Hotspot
+    from sonar.issues import Issue
     from sonar.platform import Platform
     from sonar.util.types import ApiPayload, ObjectJsonRepr
 

--- a/sonar/applications.py
+++ b/sonar/applications.py
@@ -21,32 +21,30 @@
 """Abstraction of the SonarQube "application" concept"""
 
 from __future__ import annotations
-from typing import Optional, Any, Union, TYPE_CHECKING
-from types import MappingProxyType
 
-import re
 import json
+import re
 from http import HTTPStatus
+from types import MappingProxyType
+from typing import TYPE_CHECKING, Any, Optional, Union
+
 from requests import RequestException
 
-import sonar.logging as log
-from sonar.util import cache
-
-from sonar.api.manager import ApiOperation as Oper
-from sonar import exceptions, projects, branches, app_branches
-from sonar.permissions import application_permissions
 import sonar.aggregations as aggr
+import sonar.logging as log
+import sonar.util.constants as c
 import sonar.util.misc as util
 import sonar.utilities as sutil
-from sonar.audit import rules, problem
-import sonar.util.constants as c
-from sonar.util import common_json_helper
-
+from sonar import app_branches, branches, exceptions, projects
+from sonar.api.manager import ApiOperation as Oper
+from sonar.audit import problem, rules
+from sonar.permissions import application_permissions
+from sonar.util import cache, common_json_helper
 
 if TYPE_CHECKING:
     from sonar.issues import Issue
     from sonar.platform import Platform
-    from sonar.util.types import ApiPayload, ConfigSettings, KeyList, ObjectJsonRepr, AppBranchDef, PermissionDef, AppBranchProjectDef
+    from sonar.util.types import ApiPayload, AppBranchDef, AppBranchProjectDef, ConfigSettings, KeyList, ObjectJsonRepr, PermissionDef
 
 
 _IMPORTABLE_PROPERTIES = ("key", "name", "description", "visibility", "branches", "permissions", "tags")

--- a/sonar/audit/__init__.py
+++ b/sonar/audit/__init__.py
@@ -20,9 +20,9 @@
 
 """sonar.audit module"""
 
-from sonar.audit import rules
-from sonar import errcodes, config
 import sonar.utilities as sutil
+from sonar import config, errcodes
+from sonar.audit import rules
 
 config.load_config_data()
 try:

--- a/sonar/audit/problem.py
+++ b/sonar/audit/problem.py
@@ -19,9 +19,9 @@
 #
 
 from __future__ import annotations
-from typing import Optional, TYPE_CHECKING
 
 import csv
+from typing import TYPE_CHECKING, Optional
 
 import sonar.logging as log
 import sonar.util.misc as util

--- a/sonar/audit/rules.py
+++ b/sonar/audit/rules.py
@@ -23,6 +23,7 @@
 import enum
 import json
 from typing import Optional
+
 import sonar.logging as log
 from sonar.audit import severities, types
 

--- a/sonar/branches.py
+++ b/sonar/branches.py
@@ -21,36 +21,35 @@
 """Abstraction of the SonarQube project branch concept"""
 
 from __future__ import annotations
-from typing import Optional, Any, Union, TYPE_CHECKING
 
 import json
 import re
+from typing import TYPE_CHECKING, Any, Optional, Union
 from urllib.parse import unquote
+
 import requests.utils
 
-from sonar.util import cache
 import sonar.logging as log
-from sonar import components, settings, exceptions
-
 import sonar.projects as proj
+import sonar.util.constants as c
 import sonar.util.misc as util
 import sonar.utilities as sutil
-
-from sonar.audit.problem import Problem
-from sonar.audit.rules import get_rule, RuleId
-import sonar.util.constants as c
+from sonar import components, exceptions, measures, settings
 from sonar.api.manager import ApiOperation as Oper
-from sonar import measures
+from sonar.audit.problem import Problem
+from sonar.audit.rules import RuleId, get_rule
+from sonar.util import cache
 
 if TYPE_CHECKING:
     from http import HTTPStatus
-    from sonar.tasks import Task
-    from sonar.issues import Issue
+
+    from sonar.components import Component
     from sonar.dependency_risks import DependencyRisk
     from sonar.hotspots import Hotspot
+    from sonar.issues import Issue
     from sonar.platform import Platform
-    from sonar.components import Component
-    from sonar.util.types import ApiPayload, ApiParams, ConfigSettings, ObjectJsonRepr
+    from sonar.tasks import Task
+    from sonar.util.types import ApiParams, ApiPayload, ConfigSettings, ObjectJsonRepr
 
 _UNSUPPORTED_IN_CE = "Branches not available in Community Edition"
 

--- a/sonar/changelog.py
+++ b/sonar/changelog.py
@@ -21,13 +21,16 @@
 """Abstraction of SonarQube finding (issue or hotspot) changelog"""
 
 from __future__ import annotations
-from typing import Optional, TYPE_CHECKING
+
+from typing import TYPE_CHECKING, Optional
+
 import sonar.logging as log
 import sonar.util.misc as util
 from sonar.util import issue_defs as idefs
 
 if TYPE_CHECKING:
     from datetime import datetime
+
     from sonar.util.types import ApiPayload
 
 

--- a/sonar/cli/audit.py
+++ b/sonar/cli/audit.py
@@ -21,26 +21,25 @@
 """Audits a SonarQube platform"""
 
 from __future__ import annotations
-from typing import TextIO, Optional, TYPE_CHECKING
 
-import os
-import json
 import csv
+import json
+import os
 import re
-from threading import Thread
 from queue import Queue
+from threading import Thread
+from typing import TYPE_CHECKING, Optional, TextIO
+
 from requests import RequestException
 
-from cli import options
-from sonar import errcodes, exceptions, version
-from sonar.util import component_helper
 import sonar.logging as log
-from sonar import platform, users, groups, qualityprofiles, qualitygates, sif, portfolios, applications, projects
-import sonar.utilities as sutil
-import sonar.util.misc as util
-from sonar.audit import problem
-from sonar.util import conf_mgr
 import sonar.util.common_helper as chelp
+import sonar.util.misc as util
+import sonar.utilities as sutil
+from cli import options
+from sonar import applications, errcodes, exceptions, groups, platform, portfolios, projects, qualitygates, qualityprofiles, sif, users, version
+from sonar.audit import problem
+from sonar.util import component_helper, conf_mgr
 
 if TYPE_CHECKING:
     from sonar.util.types import ConfigSettings, KeyList

--- a/sonar/cli/config.py
+++ b/sonar/cli/config.py
@@ -20,33 +20,42 @@
 #
 """Exports SonarQube platform configuration as JSON"""
 
-from typing import TextIO, Any, Optional
-from threading import Thread
-from queue import Queue
-
 import json
+import pathlib
+from queue import Queue
+from threading import Thread
+from typing import Any, Optional, TextIO
+
 import jsonschema
 import yaml
-import pathlib
-
-from cli import options
-from sonar import exceptions, errcodes, version
-from sonar.util import misc as util
-import sonar.utilities as sutil
-from sonar.util import types, constants as c
-from sonar.util import platform_helper as pfhelp
-from sonar.util import project_helper as pjhelp
-from sonar.util import portfolio_helper as foliohelp
-from sonar.util import qualityprofile_helper as qphelp
-from sonar.util import rule_helper as rhelp
-from sonar.util import misc
 
 import sonar.logging as log
-from sonar import platform, rules, qualityprofiles, qualitygates, users, groups
-from sonar import projects, portfolios, applications, license_profiles
-from sonar.util import component_helper
 import sonar.util.common_helper as chelp
-
+import sonar.utilities as sutil
+from cli import options
+from sonar import (
+    applications,
+    errcodes,
+    exceptions,
+    groups,
+    license_profiles,
+    platform,
+    portfolios,
+    projects,
+    qualitygates,
+    qualityprofiles,
+    rules,
+    users,
+    version,
+)
+from sonar.util import component_helper, misc, types
+from sonar.util import constants as c
+from sonar.util import misc as util
+from sonar.util import platform_helper as pfhelp
+from sonar.util import portfolio_helper as foliohelp
+from sonar.util import project_helper as pjhelp
+from sonar.util import qualityprofile_helper as qphelp
+from sonar.util import rule_helper as rhelp
 
 TOOL_NAME = "sonar-config"
 

--- a/sonar/cli/maturity.py
+++ b/sonar/cli/maturity.py
@@ -20,30 +20,25 @@
 #
 """Computes SonarQube maturity metrics"""
 
-from typing import Any
-
+import concurrent.futures
 import os
 import traceback
-import concurrent.futures
-from termgraph import Data, Args, BarChart
+from typing import Any
 
-from sonar import version
+from termgraph import Args, BarChart, Data
+
+import sonar.util.misc as util
+import sonar.utilities as sutil
 from cli import options
-from sonar import exceptions
-from sonar import platform
-from sonar.util import common_helper as chelp
-from sonar.util import component_helper
-from sonar import errcodes
-from sonar import projects
-from sonar.portfolios import Portfolio
-from sonar.projects import Project
+from sonar import errcodes, exceptions, languages, platform, projects, version
+from sonar import logging as log
 from sonar import qualitygates as qg
 from sonar import qualityprofiles as qp
-from sonar import languages
-from sonar import logging as log
+from sonar.portfolios import Portfolio
+from sonar.projects import Project
+from sonar.util import common_helper as chelp
+from sonar.util import component_helper
 from sonar.util import conf_mgr as conf
-import sonar.utilities as sutil
-import sonar.util.misc as util
 from sonar.util import constants as c
 
 TOOL_NAME = "sonar-maturity"

--- a/sonar/cli/misra.py
+++ b/sonar/cli/misra.py
@@ -22,6 +22,7 @@
 
 import sys
 from unittest.mock import patch
+
 from cli import findings_export
 from cli.options import TAGS
 

--- a/sonar/components.py
+++ b/sonar/components.py
@@ -20,29 +20,30 @@
 """Abstraction of the SonarQube "component" concept"""
 
 from __future__ import annotations
-from typing import Any, Optional, TYPE_CHECKING
+
 import json
+from typing import TYPE_CHECKING, Any, Optional
 
 from requests import RequestException
 
-from sonar.sqobject import SqObject
-import sonar.util.constants as c
 import sonar.logging as log
-from sonar import settings, measures, rules, exceptions
+import sonar.util.constants as c
 import sonar.util.misc as util
 import sonar.utilities as sutil
+from sonar import exceptions, measures, rules, settings
 from sonar.api.manager import ApiOperation as Oper
-
 from sonar.audit.problem import Problem
-from sonar.audit.rules import get_rule, RuleId
+from sonar.audit.rules import RuleId, get_rule
+from sonar.sqobject import SqObject
 
 if TYPE_CHECKING:
     from datetime import datetime
-    from sonar.tasks import Task
-    from sonar.platform import Platform
+
+    from sonar.dependency_risks import DependencyRisk
     from sonar.hotspots import Hotspot
     from sonar.issues import Issue
-    from sonar.dependency_risks import DependencyRisk
+    from sonar.platform import Platform
+    from sonar.tasks import Task
     from sonar.util.types import ApiPayload, ConfigSettings, KeyList
 
 

--- a/sonar/config.py
+++ b/sonar/config.py
@@ -20,9 +20,9 @@
 
 """sonar-config utils"""
 
-import pathlib
 import datetime
 import json
+import pathlib
 from typing import Optional
 
 _CONFIG_DATA = None

--- a/sonar/custom_measures.py
+++ b/sonar/custom_measures.py
@@ -22,8 +22,8 @@
 import json
 from typing import Any, Optional
 
-from sonar.sqobject import SqObject
 from sonar.platform import Platform
+from sonar.sqobject import SqObject
 from sonar.util.types import ApiPayload
 
 

--- a/sonar/dce/app_nodes.py
+++ b/sonar/dce/app_nodes.py
@@ -20,18 +20,19 @@
 """Abstraction of the App Node concept"""
 
 from __future__ import annotations
-from typing import Optional, Union, TYPE_CHECKING
 
+from typing import TYPE_CHECKING, Optional, Union
 
-import sonar.logging as log
-import sonar.utilities as sutil
-from sonar.audit.rules import get_rule, RuleId
-import sonar.sif_node as sifn
-from sonar.audit.problem import Problem
 import sonar.dce.nodes as dce_nodes
+import sonar.logging as log
+import sonar.sif_node as sifn
+import sonar.utilities as sutil
+from sonar.audit.problem import Problem
+from sonar.audit.rules import RuleId, get_rule
 
 if TYPE_CHECKING:
     import datetime
+
     from sonar.util.types import ConfigSettings
 
 _SYSTEM = "System"

--- a/sonar/dce/nodes.py
+++ b/sonar/dce/nodes.py
@@ -20,6 +20,7 @@
 """Abstraction of the DCE Node concept"""
 
 from __future__ import annotations
+
 from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:

--- a/sonar/dce/search_nodes.py
+++ b/sonar/dce/search_nodes.py
@@ -20,19 +20,18 @@
 """Abstraction of the Search Node concept"""
 
 from __future__ import annotations
-from typing import Optional, TYPE_CHECKING
+
+from typing import TYPE_CHECKING, Optional
 
 if TYPE_CHECKING:
     from sonar.util.types import ConfigSettings
 
 import sonar.logging as log
-
-import sonar.utilities as sutil
-from sonar.audit.rules import get_rule, RuleId
-from sonar.audit.problem import Problem
-from sonar.dce import nodes
 import sonar.util.constants as c
-
+import sonar.utilities as sutil
+from sonar.audit.problem import Problem
+from sonar.audit.rules import RuleId, get_rule
+from sonar.dce import nodes
 
 _STORE_SIZE = "Store Size"
 _ES_STATE = "Search State"

--- a/sonar/dependency_risk_changelog.py
+++ b/sonar/dependency_risk_changelog.py
@@ -21,15 +21,16 @@
 """Changelog adapter for SCA dependency risk changelog format"""
 
 from __future__ import annotations
-from typing import Optional, TYPE_CHECKING
 
 import re
+from typing import TYPE_CHECKING, Optional
 
 import sonar.logging as log
 import sonar.util.misc as util
 
 if TYPE_CHECKING:
     from datetime import datetime
+
     from sonar.util.types import ApiPayload
 
 # SCA timestamps include milliseconds (e.g. "2026-03-27T08:42:12.993Z")

--- a/sonar/dependency_risks.py
+++ b/sonar/dependency_risks.py
@@ -21,21 +21,22 @@
 """Abstraction of SonarQube SCA dependency risks (issue-release pairs)"""
 
 from __future__ import annotations
-from typing import Any, Optional, TYPE_CHECKING
 
 import json
 from http import HTTPStatus
+from typing import TYPE_CHECKING, Any, Optional
 
-from sonar.sqobject import SqObject
-from sonar.dependency_risk_changelog import DependencyRiskChangelog
 import sonar.logging as log
-from sonar.util import cache
-from sonar import exceptions
 import sonar.util.issue_defs as idefs
+from sonar import exceptions
 from sonar.api.manager import ApiOperation as Oper
+from sonar.dependency_risk_changelog import DependencyRiskChangelog
+from sonar.sqobject import SqObject
+from sonar.util import cache
 
 if TYPE_CHECKING:
     from datetime import datetime
+
     from sonar.platform import Platform
     from sonar.util.types import ApiPayload, ConfigSettings, ObjectJsonRepr
 

--- a/sonar/devops.py
+++ b/sonar/devops.py
@@ -21,15 +21,17 @@
 """Abstraction of the SonarQube DevOps platform concept"""
 
 from __future__ import annotations
-from typing import Optional, TYPE_CHECKING
+
 import json
-from sonar.sqobject import SqObject
+from typing import TYPE_CHECKING, Optional
+
 import sonar.logging as log
-from sonar.util import cache
-from sonar import exceptions
-import sonar.util.misc as util
 import sonar.util.constants as c
+import sonar.util.misc as util
+from sonar import exceptions
 from sonar.api.manager import ApiOperation as Oper
+from sonar.sqobject import SqObject
+from sonar.util import cache
 
 if TYPE_CHECKING:
     from sonar.platform import Platform

--- a/sonar/findings.py
+++ b/sonar/findings.py
@@ -20,32 +20,32 @@
 """Findings abstraction"""
 
 from __future__ import annotations
+
 import concurrent.futures
 import contextlib
-from typing import Optional, Any, Union, TYPE_CHECKING
-
 import json
 import re
+from typing import TYPE_CHECKING, Any, Optional, Union
+
 import Levenshtein
 
-from sonar.sqobject import SqObject
 import sonar.logging as log
-from sonar.util import constants as c
-from sonar import exceptions
-
+import sonar.util.issue_defs as idefs
 import sonar.util.misc as util
 import sonar.utilities as sutil
-from sonar import projects, rules
-import sonar.util.issue_defs as idefs
+from sonar import exceptions, projects, rules
 from sonar.api.manager import ApiOperation as Oper
+from sonar.sqobject import SqObject
+from sonar.util import constants as c
 
 if TYPE_CHECKING:
-    from sonar.issues import Issue
-    from sonar.hotspots import Hotspot
-    from sonar.platform import Platform
     from datetime import datetime
-    from sonar.util.types import ApiPayload, ObjectJsonRepr
+
     from sonar.changelog import Changelog
+    from sonar.hotspots import Hotspot
+    from sonar.issues import Issue
+    from sonar.platform import Platform
+    from sonar.util.types import ApiPayload, ObjectJsonRepr
 
     IssueOrHotspot = Union[Issue, Hotspot]
 

--- a/sonar/groups.py
+++ b/sonar/groups.py
@@ -22,24 +22,24 @@
 """Abstraction of the SonarQube group concept"""
 
 from __future__ import annotations
-import json
 
-from typing import Optional, Any, TYPE_CHECKING
-from sonar.sqobject import SqObject
+import json
+from typing import TYPE_CHECKING, Any, Optional
+
 import sonar.logging as log
 import sonar.util.misc as util
 import sonar.utilities as sutil
-from sonar import exceptions
-from sonar import users
-from sonar.util import cache, constants as c
-
+from sonar import exceptions, users
+from sonar.api.manager import ApiOperation as Oper
 from sonar.audit import rules
 from sonar.audit.problem import Problem
-from sonar.api.manager import ApiOperation as Oper
+from sonar.sqobject import SqObject
+from sonar.util import cache
+from sonar.util import constants as c
 
 if TYPE_CHECKING:
     from sonar.platform import Platform
-    from sonar.util.types import ApiPayload, ObjectJsonRepr, ConfigSettings, KeyList
+    from sonar.util.types import ApiPayload, ConfigSettings, KeyList, ObjectJsonRepr
 
 ADD_USER = "ADD_USER"
 REMOVE_USER = "REMOVE_USER"

--- a/sonar/hotspots.py
+++ b/sonar/hotspots.py
@@ -20,29 +20,29 @@
 """Abstraction of the SonarQube "hotspot" concept"""
 
 from __future__ import annotations
-from typing import Optional, Any, Union, TYPE_CHECKING
 
 import json
 from copy import deepcopy
+from typing import TYPE_CHECKING, Any, Optional, Union
+
 import requests.utils
 
 import sonar.logging as log
-import sonar.util.misc as util
-from sonar.util import cache, constants as c
-
-from sonar import users
-from sonar import findings, rules, changelog
-from sonar import exceptions
 import sonar.util.issue_defs as idefs
+import sonar.util.misc as util
 import sonar.utilities as sutil
+from sonar import changelog, exceptions, findings, rules, users
 from sonar.api.manager import ApiOperation as Oper
+from sonar.util import cache
+from sonar.util import constants as c
 
 if TYPE_CHECKING:
     from datetime import datetime
-    from sonar.platform import Platform
-    from sonar.util.types import ApiParams, ApiPayload, ObjectJsonRepr, ConfigSettings
-    from sonar.projects import Project
+
     from sonar.findings import IssueOrHotspot
+    from sonar.platform import Platform
+    from sonar.projects import Project
+    from sonar.util.types import ApiParams, ApiPayload, ConfigSettings, ObjectJsonRepr
 
 PROJECT_FILTER = "project"
 PROJECT_FILTER_OLD = "projectKey"

--- a/sonar/issues.py
+++ b/sonar/issues.py
@@ -21,30 +21,30 @@
 """Abstraction of the SonarQube issue concept"""
 
 from __future__ import annotations
-from typing import Any, Union, Optional, TYPE_CHECKING
 
-import math
-from datetime import date, datetime, timedelta
+import concurrent.futures
 import json
+import math
 import re
 from copy import deepcopy
-import concurrent.futures
+from datetime import date, datetime, timedelta
+from typing import TYPE_CHECKING, Any, Optional, Union
+
 import requests.utils
 
 import sonar.logging as log
-from sonar.util import cache, issue_defs as idefs
 import sonar.util.constants as c
-
-from sonar import users, findings, changelog, rules, config, exceptions, errcodes
-from sonar.projects import Project
-
 import sonar.util.misc as util
 import sonar.utilities as sutil
+from sonar import changelog, config, errcodes, exceptions, findings, rules, users
 from sonar.api.manager import ApiOperation as Oper
+from sonar.projects import Project
+from sonar.util import cache
+from sonar.util import issue_defs as idefs
 
 if TYPE_CHECKING:
     from sonar.platform import Platform
-    from sonar.util.types import SearchParams, ApiPayload, ObjectJsonRepr, ConfigSettings
+    from sonar.util.types import ApiPayload, ConfigSettings, ObjectJsonRepr, SearchParams
 
 
 _MAX_FACETS = 100

--- a/sonar/languages.py
+++ b/sonar/languages.py
@@ -22,14 +22,15 @@
 """Abstraction of the SonarQube language concept"""
 
 from __future__ import annotations
-from typing import Optional, Any, TYPE_CHECKING
 
 import json
-from sonar.sqobject import SqObject
-from sonar import rules
-from sonar.util import cache
+from typing import TYPE_CHECKING, Any, Optional
+
 import sonar.util.issue_defs as idefs
+from sonar import rules
 from sonar.api.manager import ApiOperation as Oper
+from sonar.sqobject import SqObject
+from sonar.util import cache
 
 if TYPE_CHECKING:
     from sonar.platform import Platform

--- a/sonar/license_profiles.py
+++ b/sonar/license_profiles.py
@@ -21,22 +21,22 @@
 """Abstraction of the SonarQube "license profile" concept (SCA / Advanced Security)"""
 
 from __future__ import annotations
-from typing import Any, Optional, TYPE_CHECKING
 
 import json
+from typing import TYPE_CHECKING, Any, Optional
 
-from sonar.sqobject import SqObject
 import sonar.logging as log
-from sonar.util import cache
-from sonar import exceptions
 import sonar.util.misc as util
 import sonar.utilities as sutil
+from sonar import exceptions
 from sonar.api.manager import ApiOperation as Oper
+from sonar.sqobject import SqObject
+from sonar.util import cache
 from sonar.util import constants as c
 
 if TYPE_CHECKING:
     from sonar.platform import Platform
-    from sonar.util.types import ApiPayload, ObjectJsonRepr, KeyList, ConfigSettings
+    from sonar.util.types import ApiPayload, ConfigSettings, KeyList, ObjectJsonRepr
 
 _IMPORTABLE_PROPERTIES = ("name", "isDefault", "categories", "licenses")
 _MIN_SQ_VERSION = (2025, 4, 0)

--- a/sonar/measures.py
+++ b/sonar/measures.py
@@ -21,27 +21,27 @@
 """Abstraction of the SonarQube measure concept"""
 
 from __future__ import annotations
-from typing import Any, Optional, Union, TYPE_CHECKING
 
 import json
+from typing import TYPE_CHECKING, Any, Optional, Union
 
-from sonar.sqobject import SqObject
-from sonar import metrics, exceptions
-from sonar.api.manager import ApiOperation as Oper
-from sonar.util import cache
 import sonar.logging as log
 import sonar.util.misc as util
 import sonar.utilities as sutil
+from sonar import exceptions, metrics
+from sonar.api.manager import ApiOperation as Oper
+from sonar.sqobject import SqObject
+from sonar.util import cache
 
 if TYPE_CHECKING:
-    from sonar.util.types import ApiPayload, ApiParams, KeyList
-    from sonar.platform import Platform
-    from sonar.projects import Project
-    from sonar.applications import Application
-    from sonar.portfolios import Portfolio
-    from sonar.branches import Branch
-    from sonar.pull_requests import PullRequest
     from sonar.app_branches import ApplicationBranch
+    from sonar.applications import Application
+    from sonar.branches import Branch
+    from sonar.platform import Platform
+    from sonar.portfolios import Portfolio
+    from sonar.projects import Project
+    from sonar.pull_requests import PullRequest
+    from sonar.util.types import ApiParams, ApiPayload, KeyList
 
     ConcernedObject = Union[Project, Application, Portfolio, Branch, PullRequest, ApplicationBranch]
 

--- a/sonar/metrics.py
+++ b/sonar/metrics.py
@@ -21,7 +21,8 @@
 """Abstraction of the SonarQube metric concept"""
 
 from __future__ import annotations
-from typing import Optional, Any, TYPE_CHECKING
+
+from typing import TYPE_CHECKING, Any, Optional
 
 from sonar.sqobject import SqObject
 from sonar.util import cache

--- a/sonar/organizations.py
+++ b/sonar/organizations.py
@@ -20,21 +20,21 @@
 """Abstraction of the SonarQube Cloud organization concept"""
 
 from __future__ import annotations
-from typing import Optional, Any, Union, TYPE_CHECKING
 
 import json
 from threading import Lock
+from typing import TYPE_CHECKING, Any, Optional, Union
 
-from sonar.sqobject import SqObject
 import sonar.logging as log
-from sonar.util import cache
-from sonar import exceptions
 import sonar.util.misc as util
+from sonar import exceptions
 from sonar.api.manager import ApiOperation as Oper
+from sonar.sqobject import SqObject
+from sonar.util import cache
 
 if TYPE_CHECKING:
     from sonar.platform import Platform
-    from sonar.util.types import ApiParams, ApiPayload, ObjectJsonRepr, KeyList
+    from sonar.util.types import ApiParams, ApiPayload, KeyList, ObjectJsonRepr
 
 
 _IMPORTABLE_PROPERTIES = ("key", "name", "description", "url", "avatar", "newCodePeriod")

--- a/sonar/permissions/aggregation_permissions.py
+++ b/sonar/permissions/aggregation_permissions.py
@@ -21,6 +21,7 @@
 """Abstraction of aggregations (portfolios or apps) permissions"""
 
 from __future__ import annotations
+
 from typing import TYPE_CHECKING
 
 from sonar.permissions import permissions, project_permissions

--- a/sonar/permissions/global_permissions.py
+++ b/sonar/permissions/global_permissions.py
@@ -21,14 +21,15 @@
 """Abstraction of SonarQube global permissions"""
 
 from __future__ import annotations
+
 from typing import TYPE_CHECKING
 
 import sonar.logging as log
-from sonar.permissions import permissions
 import sonar.util.constants as c
+from sonar.permissions import permissions
 
 if TYPE_CHECKING:
-    from sonar.util.types import PermissionDef, ObjectJsonRepr
+    from sonar.util.types import ObjectJsonRepr, PermissionDef
 
 
 class GlobalPermissions(permissions.Permissions):

--- a/sonar/permissions/permission_templates.py
+++ b/sonar/permissions/permission_templates.py
@@ -21,22 +21,22 @@
 """Abstraction of the SonarQube permission template concept"""
 
 from __future__ import annotations
-from typing import Optional, Any, TYPE_CHECKING
 
 import json
 import re
+from typing import TYPE_CHECKING, Any, Optional
 
-import sonar.logging as log
-from sonar.util import cache
-from sonar.util import platform_helper as phelp
-from sonar import sqobject, exceptions
-from sonar.permissions import template_permissions
-from sonar.audit.rules import get_rule, RuleId
 import sonar.audit.problem as pb
+import sonar.logging as log
 import sonar.util.constants as c
 import sonar.util.misc as util
 import sonar.utilities as sutil
+from sonar import exceptions, sqobject
 from sonar.api.manager import ApiOperation as Oper
+from sonar.audit.rules import RuleId, get_rule
+from sonar.permissions import template_permissions
+from sonar.util import cache
+from sonar.util import platform_helper as phelp
 
 if TYPE_CHECKING:
     from sonar.platform import Platform

--- a/sonar/permissions/permissions.py
+++ b/sonar/permissions/permissions.py
@@ -21,21 +21,21 @@
 """Abstract permissions class, parent of sub-objects permissions classes"""
 
 from __future__ import annotations
-from typing import Optional, Any, TYPE_CHECKING
 
 import json
 from abc import ABC, abstractmethod
+from typing import TYPE_CHECKING, Any, Optional
 
 import sonar.logging as log
-from sonar import exceptions
-import sonar.utilities as sutil
-import sonar.util.misc as util
-from sonar.audit.rules import get_rule, RuleId
-from sonar.audit.problem import Problem
 import sonar.util.constants as c
+import sonar.util.misc as util
+import sonar.utilities as sutil
+from sonar import exceptions
+from sonar.audit.problem import Problem
+from sonar.audit.rules import RuleId, get_rule
 
 if TYPE_CHECKING:
-    from sonar.util.types import ConfigSettings, PermissionDef, JsonPermissions
+    from sonar.util.types import ConfigSettings, JsonPermissions, PermissionDef
 
 COMMUNITY_GLOBAL_PERMISSIONS = {
     "admin": "Administer System",

--- a/sonar/permissions/project_permissions.py
+++ b/sonar/permissions/project_permissions.py
@@ -21,15 +21,16 @@
 """Projects permissions class"""
 
 from __future__ import annotations
-from typing import Callable, TYPE_CHECKING
+
+from typing import TYPE_CHECKING, Callable
 
 import sonar.logging as log
-from sonar.permissions import permissions
-from sonar.audit.rules import get_rule, RuleId
 from sonar.audit.problem import Problem
+from sonar.audit.rules import RuleId, get_rule
+from sonar.permissions import permissions
 
 if TYPE_CHECKING:
-    from sonar.util.types import PermissionDef, ConfigSettings
+    from sonar.util.types import ConfigSettings, PermissionDef
 
 PROJECT_PERMISSIONS = {
     "user": "Browse",

--- a/sonar/permissions/quality_permissions.py
+++ b/sonar/permissions/quality_permissions.py
@@ -21,13 +21,13 @@
 """Parent permissions class for quality gates and quality profiles permissions subclasses"""
 
 from __future__ import annotations
-from typing import Optional, Callable, Any, TYPE_CHECKING
 
 import json
+from typing import TYPE_CHECKING, Any, Callable, Optional
 
 import sonar.logging as log
-from sonar import exceptions
 import sonar.utilities as sutil
+from sonar import exceptions
 from sonar.permissions import permissions
 
 if TYPE_CHECKING:

--- a/sonar/permissions/qualitygate_permissions.py
+++ b/sonar/permissions/qualitygate_permissions.py
@@ -23,6 +23,7 @@
 from __future__ import annotations
 
 from typing import Any
+
 import sonar.logging as log
 from sonar.permissions import permissions, quality_permissions
 

--- a/sonar/permissions/qualityprofile_permissions.py
+++ b/sonar/permissions/qualityprofile_permissions.py
@@ -21,6 +21,7 @@
 """Quality profiles permissions class"""
 
 from __future__ import annotations
+
 from typing import TYPE_CHECKING
 
 from sonar.permissions import permissions, quality_permissions

--- a/sonar/permissions/template_permissions.py
+++ b/sonar/permissions/template_permissions.py
@@ -21,6 +21,7 @@
 """Permissions templates permissions class"""
 
 from __future__ import annotations
+
 from typing import TYPE_CHECKING
 
 import sonar.logging as log

--- a/sonar/platform.py
+++ b/sonar/platform.py
@@ -20,33 +20,32 @@
 """Abstraction of the SonarQube platform or instance concept"""
 
 from __future__ import annotations
-from typing import Any, Union, Optional, Callable, TYPE_CHECKING
 
-from http import HTTPStatus
-import re
-import time
 import datetime
 import json
+import re
+import time
+from http import HTTPStatus
+from typing import TYPE_CHECKING, Any, Callable, Optional, Union
+
 import requests
 from requests import HTTPError, RequestException
 
-import sonar.logging as log
-import sonar.util.misc as util
-import sonar.utilities as sutil
-from sonar.util import update_center
-import sonar.util.constants as c
-import sonar.util.platform_helper as pfhelp
-
-from sonar import errcodes, settings, devops, version, sif, exceptions, organizations
-from sonar.permissions import permissions, global_permissions, permission_templates
-from sonar.audit.rules import get_rule, RuleId
 import sonar.audit.severities as sev
 import sonar.audit.types as typ
-from sonar.audit.problem import Problem
-from sonar import webhooks
-from sonar.api.manager import ApiOperation as Oper
+import sonar.logging as log
+import sonar.util.constants as c
+import sonar.util.misc as util
+import sonar.util.platform_helper as pfhelp
+import sonar.utilities as sutil
+from sonar import devops, errcodes, exceptions, organizations, settings, sif, version, webhooks
 from sonar.api.manager import ApiManager as Api
+from sonar.api.manager import ApiOperation as Oper
+from sonar.audit.problem import Problem
+from sonar.audit.rules import RuleId, get_rule
+from sonar.permissions import global_permissions, permission_templates, permissions
 from sonar.settings import Setting
+from sonar.util import update_center
 
 if TYPE_CHECKING:
     from sonar.util.types import ApiParams, ApiPayload, ConfigSettings, KeyList, ObjectJsonRepr

--- a/sonar/portfolio_reference.py
+++ b/sonar/portfolio_reference.py
@@ -20,18 +20,19 @@
 """Abstraction of the Sonar sub-portfolio by reference concept"""
 
 from __future__ import annotations
-from typing import TYPE_CHECKING
-from sonar.sqobject import SqObject
-import sonar.logging as log
-from sonar.util import cache
 
-from sonar import exceptions
+from typing import TYPE_CHECKING
+
+import sonar.logging as log
 import sonar.util.constants as c
+from sonar import exceptions
+from sonar.sqobject import SqObject
+from sonar.util import cache
 
 if TYPE_CHECKING:
     from sonar.platform import Platform
-    from sonar.util.types import ApiParams, ObjectJsonRepr, ConfigSettings
     from sonar.portfolios import Portfolio
+    from sonar.util.types import ApiParams, ConfigSettings, ObjectJsonRepr
 
 
 class PortfolioReference(SqObject):

--- a/sonar/portfolios.py
+++ b/sonar/portfolios.py
@@ -20,31 +20,29 @@
 """Abstraction of the SonarQube "portfolio" concept"""
 
 from __future__ import annotations
-from typing import Optional, Union, Any, TYPE_CHECKING
 
-import re
 import json
+import re
 from http import HTTPStatus
+from typing import TYPE_CHECKING, Any, Optional, Union
 
 import sonar.logging as log
-from sonar.util import cache
-import sonar.util.constants as c
-
-from sonar import aggregations, exceptions, applications, app_branches
-from sonar.projects import Project
-
 import sonar.permissions.portfolio_permissions as pperms
+import sonar.util.constants as c
 import sonar.util.misc as util
 import sonar.utilities as sutil
-from sonar.audit import rules, problem
-from sonar.portfolio_reference import PortfolioReference
-from sonar.util import portfolio_helper as phelp
+from sonar import aggregations, app_branches, applications, exceptions
 from sonar.api.manager import ApiOperation as Oper
+from sonar.audit import problem, rules
+from sonar.portfolio_reference import PortfolioReference
+from sonar.projects import Project
+from sonar.util import cache
+from sonar.util import portfolio_helper as phelp
 
 if TYPE_CHECKING:
+    from sonar.branches import Branch
     from sonar.platform import Platform
     from sonar.util.types import ApiPayload, ConfigSettings, KeyList, ObjectJsonRepr, PermissionDef
-    from sonar.branches import Branch
 
 _PORTFOLIO_QUALIFIER = "VW"
 _SUBPORTFOLIO_QUALIFIER = "SVW"

--- a/sonar/projects.py
+++ b/sonar/projects.py
@@ -20,46 +20,42 @@
 """Abstraction of the SonarQube "project" concept"""
 
 from __future__ import annotations
-from typing import Optional, Union, Any, TYPE_CHECKING
-from types import MappingProxyType
 
+import concurrent.futures
+import json
 import os
 import re
-import json
-import concurrent.futures
-from datetime import datetime
 import traceback
-
+from datetime import datetime
 from http import HTTPStatus
+from types import MappingProxyType
+from typing import TYPE_CHECKING, Any, Optional, Union
+
 from requests import RequestException
 
 import sonar.logging as log
-from sonar.components import Component
-import sonar.util.issue_defs as idefs
-from sonar.util import cache
-from sonar import exceptions
-from sonar import qualityprofiles, settings, webhooks, devops
-from sonar import qualitygates as qg
-from sonar import pull_requests, branches
-import sonar.util.misc as util
 import sonar.permissions.project_permissions as pperms
-import sonar.utilities as sutil
-
-from sonar.audit import severities
-from sonar.audit.rules import get_rule, RuleId
-from sonar.audit.problem import Problem
 import sonar.util.constants as c
+import sonar.util.issue_defs as idefs
+import sonar.util.misc as util
 import sonar.util.project_helper as phelp
+import sonar.utilities as sutil
+from sonar import branches, devops, exceptions, measures, pull_requests, qualityprofiles, settings, webhooks
+from sonar import qualitygates as qg
 from sonar.api.manager import ApiOperation as Oper
-from sonar import measures
+from sonar.audit import severities
+from sonar.audit.problem import Problem
+from sonar.audit.rules import RuleId, get_rule
+from sonar.components import Component
+from sonar.util import cache
 
 if TYPE_CHECKING:
-    from sonar.tasks import Task
     from sonar.branches import Branch
-    from sonar.pull_requests import PullRequest
-    from sonar.issues import Issue
     from sonar.hotspots import Hotspot
+    from sonar.issues import Issue
     from sonar.platform import Platform
+    from sonar.pull_requests import PullRequest
+    from sonar.tasks import Task
     from sonar.util.types import ApiParams, ApiPayload, ConfigSettings, KeyList, ObjectJsonRepr, PermissionDef
 
 MAX_PAGE_SIZE = 500
@@ -604,7 +600,7 @@ class Project(Component):
         :param int timeout: timeout in seconds to complete the export operation
         :returns: export status (success/failure/timeout), and zip file path
         """
-        from sonar.tasks import Task, SUCCESS
+        from sonar.tasks import SUCCESS, Task
 
         log.info("Exporting %s (%s)", str(self), "asynchronously" if asynchronous else "synchronously")
         try:
@@ -641,7 +637,7 @@ class Project(Component):
         :param int timeout: timeout in seconds to complete the export operation
         :return: SUCCESS or FAILED with reason
         """
-        from sonar.tasks import Task, ZIP_MISSING, SUCCESS
+        from sonar.tasks import SUCCESS, ZIP_MISSING, Task
 
         mode = "asynchronously" if asynchronous else "synchronously"
         log.info("Importing %s (%s)", str(self), mode)
@@ -704,7 +700,7 @@ class Project(Component):
         :param search_params: Any search parameter
         :return: List of all findings, with finding key as key
         """
-        from sonar import issues, hotspots, findings
+        from sonar import findings, hotspots, issues
 
         log.info("Exporting findings for %s with params %s", str(self), search_params)
         findings_list: dict[str, Union[Issue, Hotspot]] = {}

--- a/sonar/projects.py
+++ b/sonar/projects.py
@@ -600,7 +600,7 @@ class Project(Component):
         :param int timeout: timeout in seconds to complete the export operation
         :returns: export status (success/failure/timeout), and zip file path
         """
-        from sonar.tasks import SUCCESS, Task
+        from sonar.tasks import SUCCESS, Task  # pylint: disable=import-outside-toplevel
 
         log.info("Exporting %s (%s)", str(self), "asynchronously" if asynchronous else "synchronously")
         try:
@@ -637,7 +637,7 @@ class Project(Component):
         :param int timeout: timeout in seconds to complete the export operation
         :return: SUCCESS or FAILED with reason
         """
-        from sonar.tasks import SUCCESS, ZIP_MISSING, Task
+        from sonar.tasks import SUCCESS, ZIP_MISSING, Task  # pylint: disable=import-outside-toplevel
 
         mode = "asynchronously" if asynchronous else "synchronously"
         log.info("Importing %s (%s)", str(self), mode)
@@ -700,7 +700,7 @@ class Project(Component):
         :param search_params: Any search parameter
         :return: List of all findings, with finding key as key
         """
-        from sonar import findings, hotspots, issues
+        from sonar import findings, hotspots, issues  # pylint: disable=import-outside-toplevel
 
         log.info("Exporting findings for %s with params %s", str(self), search_params)
         findings_list: dict[str, Union[Issue, Hotspot]] = {}

--- a/sonar/pull_requests.py
+++ b/sonar/pull_requests.py
@@ -20,29 +20,29 @@
 """Abstraction of the SonarQube "pull request" concept"""
 
 from __future__ import annotations
-from typing import Optional, Union, Any, TYPE_CHECKING
 
 import json
+from typing import TYPE_CHECKING, Any, Optional, Union
+
 import requests.utils
 
 import sonar.logging as log
-from sonar.util import cache
-from sonar import exceptions
-from sonar.components import Component
-import sonar.util.misc as util
-from sonar.audit.rules import get_rule, RuleId
-from sonar.audit.problem import Problem
 import sonar.util.constants as c
-from sonar.api.manager import ApiOperation as Oper
+import sonar.util.misc as util
+from sonar import exceptions, measures
 from sonar import projects as proj
-from sonar import measures
+from sonar.api.manager import ApiOperation as Oper
+from sonar.audit.problem import Problem
+from sonar.audit.rules import RuleId, get_rule
+from sonar.components import Component
+from sonar.util import cache
 
 if TYPE_CHECKING:
-    from sonar.issues import Issue
-    from sonar.hotspots import Hotspot
     from sonar.dependency_risks import DependencyRisk
-    from sonar.util.types import ApiPayload, ConfigSettings
+    from sonar.hotspots import Hotspot
+    from sonar.issues import Issue
     from sonar.platform import Platform
+    from sonar.util.types import ApiPayload, ConfigSettings
 
 _UNSUPPORTED_IN_CE = "Pull requests not available in Community Edition"
 

--- a/sonar/qualitygates.py
+++ b/sonar/qualitygates.py
@@ -21,28 +21,25 @@
 """Abstraction of the SonarQube "quality gate" concept"""
 
 from __future__ import annotations
-from typing import Optional, Any, Union, TYPE_CHECKING
 
 import json
+from typing import TYPE_CHECKING, Any, Optional, Union
 
-from sonar.sqobject import SqObject
 import sonar.logging as log
-from sonar.util import cache
-from sonar import measures, exceptions
-from sonar.util import constants as c
-from sonar import projects
 import sonar.permissions.qualitygate_permissions as permissions
 import sonar.util.misc as util
 import sonar.utilities as sutil
-
-from sonar.audit.rules import get_rule, RuleId
-from sonar.audit.problem import Problem
-from sonar.util import common_json_helper
+from sonar import exceptions, measures, projects
 from sonar.api.manager import ApiOperation as Oper
+from sonar.audit.problem import Problem
+from sonar.audit.rules import RuleId, get_rule
+from sonar.sqobject import SqObject
+from sonar.util import cache, common_json_helper
+from sonar.util import constants as c
 
 if TYPE_CHECKING:
     from sonar.platform import Platform
-    from sonar.util.types import ApiPayload, ObjectJsonRepr, KeyList, ConfigSettings
+    from sonar.util.types import ApiPayload, ConfigSettings, KeyList, ObjectJsonRepr
 
 __MAX_ISSUES_SHOULD_BE_ZERO = "Any numeric threshold on number of issues should be 0 or should be removed from QG conditions"
 __THRESHOLD_ON_OVERALL_CODE = "Threshold on overall code should not be too strict or passing the QG will often be impossible"

--- a/sonar/qualityprofiles.py
+++ b/sonar/qualityprofiles.py
@@ -21,34 +21,34 @@
 """Abstraction of the SonarQube Quality Profile concept"""
 
 from __future__ import annotations
-from typing import Optional, Any, TYPE_CHECKING
 
-import json
-from copy import deepcopy
-import traceback
 import concurrent.futures
-
+import json
+import traceback
+from copy import deepcopy
 from threading import Lock
+from typing import TYPE_CHECKING, Any, Optional
+
 import requests.utils
 
-from sonar.sqobject import SqObject
 import sonar.logging as log
-from sonar.util import cache, constants as c
-from sonar.util import qualityprofile_helper as qphelp
-from sonar import exceptions
-from sonar import rules, languages
 import sonar.permissions.qualityprofile_permissions as permissions
 import sonar.util.misc as util
 import sonar.utilities as sutil
-
-from sonar.audit.rules import get_rule, RuleId
-from sonar.audit.problem import Problem
+from sonar import exceptions, languages, rules
 from sonar.api.manager import ApiOperation as Oper
+from sonar.audit.problem import Problem
+from sonar.audit.rules import RuleId, get_rule
+from sonar.sqobject import SqObject
+from sonar.util import cache
+from sonar.util import constants as c
+from sonar.util import qualityprofile_helper as qphelp
 
 if TYPE_CHECKING:
     from datetime import datetime
+
     from sonar.platform import Platform
-    from sonar.util.types import ApiPayload, ObjectJsonRepr, KeyList, ConfigSettings
+    from sonar.util.types import ApiPayload, ConfigSettings, KeyList, ObjectJsonRepr
 
 _IMPORTABLE_PROPERTIES = ("name", "language", "parentName", "isBuiltIn", "isDefault", "rules", "permissions", "prioritizedRules")
 

--- a/sonar/rules.py
+++ b/sonar/rules.py
@@ -20,19 +20,21 @@
 """Abstraction of the SonarQube "rule" concept"""
 
 from __future__ import annotations
-from typing import Optional, Any, TYPE_CHECKING
 
-import json
 import concurrent.futures
+import json
+from typing import TYPE_CHECKING, Any, Optional
 
-from sonar.sqobject import SqObject
 import sonar.logging as log
-from sonar.util import cache, constants as c, issue_defs as idefs
-from sonar import exceptions, languages
 import sonar.util.misc as util
 import sonar.utilities as sutil
-from sonar.util import rule_helper as rhelp
+from sonar import exceptions, languages
 from sonar.api.manager import ApiOperation as Oper
+from sonar.sqobject import SqObject
+from sonar.util import cache
+from sonar.util import constants as c
+from sonar.util import issue_defs as idefs
+from sonar.util import rule_helper as rhelp
 
 if TYPE_CHECKING:
     from sonar.platform import Platform

--- a/sonar/settings.py
+++ b/sonar/settings.py
@@ -20,17 +20,18 @@
 """Abstraction of the SonarQube setting concept"""
 
 from __future__ import annotations
-from typing import Any, Union, Optional, TYPE_CHECKING
 
-import re
 import json
+import re
+from typing import TYPE_CHECKING, Any, Optional, Union
+
 import sonar.logging as log
-from sonar.util import cache
-from sonar import exceptions
-from sonar.util import constants as c
-from sonar.sqobject import SqObject
 import sonar.util.misc as util
+from sonar import exceptions
 from sonar.api.manager import ApiOperation as Oper
+from sonar.sqobject import SqObject
+from sonar.util import cache
+from sonar.util import constants as c
 
 if TYPE_CHECKING:
     from sonar.platform import Platform

--- a/sonar/sif.py
+++ b/sonar/sif.py
@@ -24,17 +24,15 @@ import datetime
 import re
 from typing import Optional
 
-import sonar.logging as log
-import sonar.utilities as sutil
-from sonar.util import types
-import sonar.util.constants as c
-from sonar.audit.rules import get_rule, RuleId
-from sonar.audit.problem import Problem
-import sonar.sif_node as sifn
-from sonar.util import misc
-
 import sonar.dce.app_nodes as appnodes
 import sonar.dce.search_nodes as searchnodes
+import sonar.logging as log
+import sonar.sif_node as sifn
+import sonar.util.constants as c
+import sonar.utilities as sutil
+from sonar.audit.problem import Problem
+from sonar.audit.rules import RuleId, get_rule
+from sonar.util import misc, types
 
 _APP_NODES = "Application Nodes"
 _ES_NODES = "Search Nodes"

--- a/sonar/sif_node.py
+++ b/sonar/sif_node.py
@@ -20,24 +20,25 @@
 """Abstraction of SIF node, for audit"""
 
 from __future__ import annotations
-from typing import Union, TYPE_CHECKING
 
 import datetime
+from typing import TYPE_CHECKING, Union
+
 from dateutil.relativedelta import relativedelta
 
 import sonar.logging as log
+import sonar.util.constants as c
 import sonar.util.misc as util
 import sonar.utilities as sutil
-from sonar.util import types, update_center
-from sonar.audit.rules import get_rule, RuleId
-from sonar.audit.problem import Problem
 from sonar import config
-import sonar.util.constants as c
+from sonar.audit.problem import Problem
+from sonar.audit.rules import RuleId, get_rule
+from sonar.util import types, update_center
 
 if TYPE_CHECKING:
-    from sonar.util.types import ConfigSettings
-    from sonar.sif import Sif
     from sonar.dce.app_nodes import AppNode
+    from sonar.sif import Sif
+    from sonar.util.types import ConfigSettings
 
 _RELEASE_DATES = {
     "2026.1": (2026, 1, 27),

--- a/sonar/sqobject.py
+++ b/sonar/sqobject.py
@@ -20,23 +20,25 @@
 """Abstraction of the SonarQube general object concept"""
 
 from __future__ import annotations
-from typing import Any, Optional, TYPE_CHECKING
 
+import concurrent.futures
 import contextlib
 import json
-import concurrent.futures
+from typing import TYPE_CHECKING, Any, Optional
 
-from sonar.api.manager import ApiOperation as Oper
 import sonar.logging as log
-from sonar.util import cache
-from sonar.util import constants as c
-from sonar import exceptions, errcodes
 import sonar.util.misc as util
 import sonar.utilities as sutil
+from sonar import errcodes, exceptions
+from sonar.api.manager import ApiOperation as Oper
+from sonar.util import cache
+from sonar.util import constants as c
 
 if TYPE_CHECKING:
     from http import HTTPStatus
+
     import requests
+
     from sonar.platform import Platform
     from sonar.util.types import ApiParams, ApiPayload
 

--- a/sonar/syncer.py
+++ b/sonar/syncer.py
@@ -21,15 +21,14 @@
 """Findings syncer"""
 
 from __future__ import annotations
-from typing import Union, TYPE_CHECKING
 
 import concurrent.futures
 import traceback
+from typing import TYPE_CHECKING, Union
 
 import sonar.logging as log
 import sonar.util.misc as util
-from sonar import findings
-from sonar import exceptions
+from sonar import exceptions, findings
 
 if TYPE_CHECKING:
     from sonar.branches import Branch

--- a/sonar/tasks.py
+++ b/sonar/tasks.py
@@ -21,37 +21,33 @@
 """Abstraction of the SonarQube background task concept"""
 
 from __future__ import annotations
-from typing import Optional, Any, Union, TYPE_CHECKING
 
-from datetime import datetime
-import time
 import json
 import re
+import time
+from datetime import datetime
+from typing import TYPE_CHECKING, Any, Optional, Union
 
-from sonar.sqobject import SqObject
 import sonar.logging as log
-from sonar import exceptions
 import sonar.utilities as sutil
-from sonar.audit.rules import get_rule, RuleId
+from sonar import applications, exceptions, portfolios, projects
+from sonar.api.manager import ApiOperation as Oper
 from sonar.audit.problem import Problem
+from sonar.audit.rules import RuleId, get_rule
 from sonar.config import get_scanners_versions
+from sonar.sqobject import SqObject
 from sonar.util import cache
 from sonar.util import misc as util
-from sonar.api.manager import ApiOperation as Oper
-
-from sonar import projects
-from sonar import applications
-from sonar import portfolios
 
 if TYPE_CHECKING:
-    from sonar.platform import Platform
-    from sonar.util.types import ApiPayload, ConfigSettings
-    from sonar.projects import Project
-    from sonar.applications import Application
-    from sonar.portfolios import Portfolio
-    from sonar.branches import Branch
-    from sonar.pull_requests import PullRequest
     from sonar.app_branches import ApplicationBranch
+    from sonar.applications import Application
+    from sonar.branches import Branch
+    from sonar.platform import Platform
+    from sonar.portfolios import Portfolio
+    from sonar.projects import Project
+    from sonar.pull_requests import PullRequest
+    from sonar.util.types import ApiPayload, ConfigSettings
 
     ConcernedObject = Union[Project, Branch, PullRequest, Application, ApplicationBranch, Portfolio]
 

--- a/sonar/tokens.py
+++ b/sonar/tokens.py
@@ -21,20 +21,21 @@
 """Abstraction of the SonarQube User Token concept"""
 
 from __future__ import annotations
-from typing import Optional, Any, TYPE_CHECKING
 
-import json
 import datetime as dt
+import json
+from typing import TYPE_CHECKING, Any, Optional
 
-from sonar.sqobject import SqObject
 import sonar.logging as log
-import sonar.utilities as sutil
 import sonar.util.misc as util
-from sonar import exceptions, errcodes
-from sonar.util import cache, constants as c
-from sonar.audit.problem import Problem
-from sonar.audit.rules import get_rule, RuleId
+import sonar.utilities as sutil
+from sonar import errcodes, exceptions
 from sonar.api.manager import ApiOperation as Oper
+from sonar.audit.problem import Problem
+from sonar.audit.rules import RuleId, get_rule
+from sonar.sqobject import SqObject
+from sonar.util import cache
+from sonar.util import constants as c
 
 if TYPE_CHECKING:
     from sonar.platform import Platform

--- a/sonar/users.py
+++ b/sonar/users.py
@@ -21,27 +21,28 @@
 """Abstraction of the SonarQube User concept"""
 
 from __future__ import annotations
-from typing import Optional, Any, TYPE_CHECKING
 
 import concurrent.futures
-from datetime import datetime, timezone, MINYEAR
 import json
+from datetime import MINYEAR, datetime, timezone
+from typing import TYPE_CHECKING, Any, Optional
+
 from requests import RequestException
 
-from sonar.sqobject import SqObject
 import sonar.logging as log
-from sonar.util import cache
 import sonar.util.constants as c
-from sonar import groups, tokens, exceptions
 import sonar.util.misc as util
 import sonar.utilities as sutil
-from sonar.audit.rules import get_rule, RuleId
-from sonar.audit.problem import Problem
+from sonar import exceptions, groups, tokens
 from sonar.api.manager import ApiOperation as Oper
+from sonar.audit.problem import Problem
+from sonar.audit.rules import RuleId, get_rule
+from sonar.sqobject import SqObject
+from sonar.util import cache
 
 if TYPE_CHECKING:
     from sonar.platform import Platform
-    from sonar.util.types import ApiPayload, ConfigSettings, ObjectJsonRepr, KeyList, AuditSettings
+    from sonar.util.types import ApiPayload, AuditSettings, ConfigSettings, KeyList, ObjectJsonRepr
 
 SETTABLE_PROPERTIES = ("login", "name", "email", "groups", "scmAccounts", "local")
 

--- a/sonar/util/cache.py
+++ b/sonar/util/cache.py
@@ -21,9 +21,10 @@
 """Cache manager"""
 
 from __future__ import annotations
-from typing import Optional, Any, TYPE_CHECKING
 
 from threading import Lock
+from typing import TYPE_CHECKING, Any, Optional
+
 import sonar.logging as log
 
 if TYPE_CHECKING:

--- a/sonar/util/cache_helper.py
+++ b/sonar/util/cache_helper.py
@@ -21,32 +21,33 @@
 """Cache manager"""
 
 from typing import Optional
-from sonar import logging as log
+
 from sonar import (
-    projects,
+    app_branches,
+    applications,
     branches,
-    pull_requests,
-    issues,
+    devops,
+    groups,
     hotspots,
+    issues,
+    languages,
     measures,
     metrics,
-    users,
-    groups,
-    rules,
-    languages,
-    qualityprofiles,
-    qualitygates,
-    portfolios,
-    applications,
-    app_branches,
-    devops,
     organizations,
     portfolio_reference,
+    portfolios,
+    projects,
+    pull_requests,
+    qualitygates,
+    qualityprofiles,
+    rules,
     settings,
-    tokens,
-    webhooks,
     tasks,
+    tokens,
+    users,
+    webhooks,
 )
+from sonar import logging as log
 from sonar.permissions import permission_templates
 
 

--- a/sonar/util/common_helper.py
+++ b/sonar/util/common_helper.py
@@ -19,10 +19,11 @@
 #
 """Common helper functions"""
 
-from typing import Optional
 from datetime import datetime
-from sonar.util import cache_helper
+from typing import Optional
+
 import sonar.utilities as sutil
+from sonar.util import cache_helper
 
 
 def clear_cache_and_exit(exit_code: int, err_msg: Optional[str] = None, start_time: Optional[datetime] = None) -> None:

--- a/sonar/util/common_json_helper.py
+++ b/sonar/util/common_json_helper.py
@@ -20,6 +20,7 @@
 """Helper tools for the Rule object"""
 
 from typing import Any
+
 import sonar.util.misc as util
 import sonar.utilities as sutil
 

--- a/sonar/util/component_helper.py
+++ b/sonar/util/component_helper.py
@@ -19,15 +19,15 @@
 #
 
 import re
-from typing import Optional, Any
+from typing import Any, Optional
 
 import sonar.logging as log
-from sonar.projects import Project
+from cli import options
 from sonar.applications import Application
-from sonar.portfolios import Portfolio
 from sonar.components import Component
 from sonar.platform import Platform
-from cli import options
+from sonar.portfolios import Portfolio
+from sonar.projects import Project
 
 
 def get_components(

--- a/sonar/util/conf_mgr.py
+++ b/sonar/util/conf_mgr.py
@@ -19,13 +19,14 @@
 #
 """Utility to manage configuration files"""
 
-import os
-from pathlib import Path
 import json
-import jprops
+import os
 import site
-
+from pathlib import Path
 from typing import Any, Union
+
+import jprops
+
 import sonar.logging as log
 from sonar.util import misc
 

--- a/sonar/util/misc.py
+++ b/sonar/util/misc.py
@@ -19,15 +19,14 @@
 #
 """Miscellaneous utilities"""
 
-from typing import Union, Optional, Any
+import contextlib
 import json
 import re
-from datetime import datetime, date, timezone, timedelta
-import contextlib
 import sys
-from typing import TextIO
 from collections.abc import Generator
 from copy import deepcopy
+from datetime import date, datetime, timedelta, timezone
+from typing import Any, Optional, TextIO, Union
 
 ISO_DATE_FORMAT = "%04d-%02d-%02d"
 

--- a/sonar/util/platform_helper.py
+++ b/sonar/util/platform_helper.py
@@ -20,10 +20,11 @@
 """Helper tools for the Platform object"""
 
 from __future__ import annotations
+
 from typing import Any
 
-from sonar import settings
 import sonar.util.misc as util
+from sonar import settings
 from sonar.util import common_json_helper
 
 _PERM_TPL_IMPORTABLE_PROPERTIES = ("name", "description", "pattern", "defaultFor", "permissions")

--- a/sonar/util/portfolio_helper.py
+++ b/sonar/util/portfolio_helper.py
@@ -20,9 +20,10 @@
 """Helper tools for the Portfolio object"""
 
 from typing import Any
+
 import sonar.util.misc as util
-from sonar.util import constants as c
 from sonar.util import common_json_helper
+from sonar.util import constants as c
 
 
 def __convert_projects_json(json_to_convert: dict[str, Any]) -> dict[str, Any]:

--- a/sonar/util/project_helper.py
+++ b/sonar/util/project_helper.py
@@ -20,6 +20,7 @@
 """Helper tools for the Project object"""
 
 from typing import Any
+
 import sonar.util.misc as util
 from sonar.util import common_json_helper
 

--- a/sonar/util/qualityprofile_helper.py
+++ b/sonar/util/qualityprofile_helper.py
@@ -20,12 +20,11 @@
 """Helper tools for the Project object"""
 
 from typing import Any
-import sonar.util.misc as util
 
-from sonar.util import constants as c
-from sonar.util import common_json_helper
 import sonar.util.issue_defs as idefs
-
+import sonar.util.misc as util
+from sonar.util import common_json_helper
+from sonar.util import constants as c
 
 KEY_PARENT = "parent"
 KEY_CHILDREN = "children"

--- a/sonar/util/rule_helper.py
+++ b/sonar/util/rule_helper.py
@@ -20,10 +20,11 @@
 """Helper tools for the Rule object"""
 
 from typing import Any
-import sonar.util.misc as util
-from sonar.util import constants as c
-from sonar.util import common_json_helper
+
 import sonar.util.issue_defs as idefs
+import sonar.util.misc as util
+from sonar.util import common_json_helper
+from sonar.util import constants as c
 
 
 def __convert_rule_json(json_to_convert: dict[str, Any]) -> dict[str, Any]:

--- a/sonar/util/sonar_cache.py
+++ b/sonar/util/sonar_cache.py
@@ -21,11 +21,28 @@
 """Cache module"""
 
 from typing import Optional
-from sonar import platform, projects, branches, pull_requests
-from sonar import applications, app_branches, portfolios
-from sonar import rules, issues, hotspots, metrics, measures
-from sonar import qualitygates, qualityprofiles
-from sonar import devops, settings, tasks, tokens, webhooks
+
+from sonar import (
+    app_branches,
+    applications,
+    branches,
+    devops,
+    hotspots,
+    issues,
+    measures,
+    metrics,
+    platform,
+    portfolios,
+    projects,
+    pull_requests,
+    qualitygates,
+    qualityprofiles,
+    rules,
+    settings,
+    tasks,
+    tokens,
+    webhooks,
+)
 
 
 def clear(endpoint: Optional[platform.Platform] = None) -> None:

--- a/sonar/util/types.py
+++ b/sonar/util/types.py
@@ -20,7 +20,7 @@
 
 """Sonar Custom Types for type hints"""
 
-from typing import Union, Optional, Any
+from typing import Any, Optional, Union
 
 ConfigSettings = dict[str, Any]
 

--- a/sonar/util/update_center.py
+++ b/sonar/util/update_center.py
@@ -20,12 +20,14 @@
 
 """Update center utilities"""
 
-import os
-from typing import Optional
 import datetime
-import requests
+import os
 import tempfile
+from typing import Optional
+
 import jprops
+import requests
+
 import sonar.logging as log
 import sonar.util.misc as util
 from sonar import version

--- a/sonar/utilities.py
+++ b/sonar/utilities.py
@@ -20,25 +20,24 @@
 
 """Utilities for sonar-tools"""
 
-from typing import Any, Union, Optional
-from http import HTTPStatus
-import sys
+import contextlib
+import datetime
+import json
 import math
 import re
-import json
-import datetime
-import contextlib
-import requests
+import sys
+from http import HTTPStatus
+from typing import Any, Optional, Union
 
 import Levenshtein
-
-import sonar.logging as log
-from sonar import version, errcodes, exceptions
-from sonar.util import types, constants as c
-import sonar.util.misc as util
+import requests
 
 import cli.options as opt
-
+import sonar.logging as log
+import sonar.util.misc as util
+from sonar import errcodes, exceptions, version
+from sonar.util import constants as c
+from sonar.util import types
 
 SQ_DATETIME_FORMAT = "%Y-%m-%dT%H:%M:%S%z"
 SQ_DATE_FORMAT = "%Y-%m-%d"

--- a/sonar/webhooks.py
+++ b/sonar/webhooks.py
@@ -21,15 +21,16 @@
 """Abstraction of the SonarQube webhook concept"""
 
 from __future__ import annotations
-from typing import Optional, ClassVar, Any, Union, TYPE_CHECKING
 
-from sonar.sqobject import SqObject
+from typing import TYPE_CHECKING, Any, ClassVar, Optional, Union
+
 import sonar.logging as log
-from sonar import exceptions, errcodes
-from sonar.util import cache
 import sonar.util.misc as util
-from sonar.audit import rules, problem
+from sonar import errcodes, exceptions
 from sonar.api.manager import ApiOperation as Oper
+from sonar.audit import problem, rules
+from sonar.sqobject import SqObject
+from sonar.util import cache
 
 if TYPE_CHECKING:
     from sonar.platform import Platform


### PR DESCRIPTION
## Summary

- **Import sorting (I001):** Ran `ruff check --select I --fix` to sort and reformat all import blocks — 123 issues fixed across 90 files.
- **ruff2sonar.py — restore json import and fix variable references:** Restored `import json` removed by previous autofix, fixed `lines[i]` → `line` variable references in regex matches, added new inline caret pattern (`^^^^`), and restored the `print` output.
- **ruff2sonar.py — fix engineId and last-issue drop:** Two bugs that prevented `external-issues-ruff.json` from loading in sonar-scanner:
  1. `engineId` was only set in v1 mode but is required at the issue level in both formats — moved it unconditionally into every issue.
  2. The last issue was silently dropped because the loop only appended on the next issue header — added a post-loop append (1125 issues now vs 1124 before).

## Test plan
- [ ] Run `conf/run_linters.sh` and verify `build/external-issues-ruff.json` is generated
- [ ] Confirm every issue in the JSON has `engineId: "ruff"`
- [ ] Run `conf/run_scanner.sh` and verify sonar-scanner loads the ruff issues without errors
- [ ] Check ruff issue count matches between the raw report and the JSON

🤖 Generated with [Claude Code](https://claude.com/claude-code)