### PR TITLE
Fix #2440: delete empty checkov SARIF, detect SARIF files dynamically in scanner

### DIFF
--- a/conf/run_linters.sh
+++ b/conf/run_linters.sh
@@ -80,6 +80,15 @@ if [[ "${localbuild}" = "true" ]]; then
     if [[ "${linters_to_run}" == *"checkov"* ]]; then
         echo "===> Running checkov"
         checkov -d . --framework dockerfile -o sarif --output-file-path "${BUILD_DIR}"
+        # Delete SARIF file if checkov found 0 results (empty results cause sonar-scanner import failure)
+        for sarif_file in "${BUILD_DIR}"/*.sarif; do
+            [[ -f "${sarif_file}" ]] || continue
+            results_count=$(python3 -c "import json,sys; d=json.load(open('${sarif_file}')); print(sum(len(r.get('results',[])) for r in d.get('runs',[])))" 2>/dev/null)
+            if [[ "${results_count}" = "0" ]]; then
+                echo "===> Deleting empty SARIF report: ${sarif_file}"
+                rm -f "${sarif_file}"
+            fi
+        done
     fi
     if [[ "${linters_to_run}" == *"trivy"* ]]; then
         echo "===> Running trivy"

--- a/conf/run_scanner.sh
+++ b/conf/run_scanner.sh
@@ -80,6 +80,14 @@ else
   echo "===> NO EXTERNAL ISSUES"
 fi
 
+if ls "${BUILD_DIR}"/*.sarif >/dev/null 2>&1; then
+  files=$(ls "${BUILD_DIR}"/*.sarif | tr '\n' ' ' | sed -E -e 's/ +$//' -e 's/ +/,/g')
+  echo "SARIF FILES = ${files}"
+  cmd="${cmd} -Dsonar.sarifReportPaths=${files}"
+else
+  echo "===> NO SARIF REPORT"
+fi
+
 echo "=============================================================="
 echo "Running: ${cmd}" | sed "s/${SONAR_TOKEN}/<SONAR_TOKEN>/g"
 echo "=============================================================="

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -11,7 +11,6 @@ sonar.sourceEncoding=UTF-8
 sonar.exclusions=doc/api/**/*, build/**/*, conf/offline/**, **/__pycache__/**, **/*.pyc, **/*.pyo
 sonar.python.flake8.reportPaths=build/flake8-report.out
 sonar.python.pylint.reportPaths=build/pylint-report.out
-sonar.sarifReportPaths=build/results_sarif.sarif
 # sonar.externalIssuesReportPaths=build/shellcheck.json,build/trivy.json
 # sonar.python.bandit.reportPaths=build/bandit-report.json
 


### PR DESCRIPTION
Fixes #2440

## Summary
- **run_linters.sh**: after checkov runs, delete any `.sarif` file whose total `runs[].results[]` count is 0 — an empty SARIF causes sonar-scanner import to fail
- **run_scanner.sh**: detect `*.sarif` files in `build/` at scan time and pass via `-Dsonar.sarifReportPaths`, same dynamic pattern used for external issues and xunit reports
- **sonar-project.properties**: remove static `sonar.sarifReportPaths` entry (now set dynamically by `run_scanner.sh` only when files are present)

## Test plan
- [ ] Run checkov on a clean Dockerfile with no issues — verify the `.sarif` file is deleted before the scanner runs
- [ ] Run checkov on a Dockerfile with issues — verify the `.sarif` file is kept and passed to sonar-scanner
- [ ] Run `conf/run_scanner.sh` with no `.sarif` in `build/` — verify "NO SARIF REPORT" is logged and property is not set

🤖 Generated with [Claude Code](https://claude.com/claude-code)