### PR TITLE
Fix #2442: generate CycloneDX SBOM with trivy and pass to sonar-scanner

### DIFF
--- a/conf/run_linters.sh
+++ b/conf/run_linters.sh
@@ -97,5 +97,7 @@ if [[ "${localbuild}" = "true" ]]; then
         cat "${BUILD_DIR}"/trivy_results.json
         python3 "${CONF_DIR}"/trivy2sonar.py "${external_format}" < "${BUILD_DIR}"/trivy_results.json > "${TRIVY_REPORT}"
         [[ ! -s "${TRIVY_REPORT}" ]] && rm -f "${TRIVY_REPORT}"
+        echo "===> Generating SBOM in CycloneDX format"
+        trivy image -f cyclonedx -o "${BUILD_DIR}"/container.cdx.json olivierkorach/sonar-tools:latest
     fi
 fi

--- a/conf/run_scanner.sh
+++ b/conf/run_scanner.sh
@@ -88,6 +88,14 @@ else
   echo "===> NO SARIF REPORT"
 fi
 
+if ls "${BUILD_DIR}"/*.cdx.json >/dev/null 2>&1; then
+  files=$(ls "${BUILD_DIR}"/*.cdx.json | tr '\n' ' ' | sed -E -e 's/ +$//' -e 's/ +/,/g')
+  echo "SBOM FILES = ${files}"
+  cmd="${cmd} -Dsonar.sca.sbomImportPaths=${files}"
+else
+  echo "===> NO SBOM"
+fi
+
 echo "=============================================================="
 echo "Running: ${cmd}" | sed "s/${SONAR_TOKEN}/<SONAR_TOKEN>/g"
 echo "=============================================================="


### PR DESCRIPTION
Fixes #2442

## Summary
- **run_linters.sh**: after the existing trivy JSON scan, runs `trivy image -f cyclonedx` to produce `build/container.cdx.json`
- **run_scanner.sh**: detects `*.cdx.json` files in `build/` and passes them via `-Dsonar.sca.sbomImportPaths`, using the same dynamic pattern as SARIF and external issues

## Test plan
- [ ] Run `conf/run_linters.sh` and verify `build/container.cdx.json` is generated
- [ ] Run `conf/run_scanner.sh` and verify `SBOM FILES = ...` is logged and the property is passed to sonar-scanner

🤖 Generated with [Claude Code](https://claude.com/claude-code)