### PR TITLE
Fix sonar.python.xunit.reportPath: pass glob pattern, not CSV list

### DIFF
--- a/conf/run_scanner.sh
+++ b/conf/run_scanner.sh
@@ -67,9 +67,8 @@ else
 fi
 
 if ls "${BUILD_DIR}"/xunit-*.xml >/dev/null 2>&1; then
-  files=$(ls "${BUILD_DIR}"/xunit-*.xml | eval "${TO_CSV}")
-  echo "XUNIT FILES = ${files}"
-  cmd="${cmd} -Dsonar.python.xunit.reportPath=${files}"
+  echo "XUNIT FILES = ${BUILD_DIR}/xunit-*.xml"
+  cmd="${cmd} -Dsonar.python.xunit.reportPath=${BUILD_DIR}/xunit-*.xml"
 else
   echo "===> NO UNIT TESTS REPORT"
 fi


### PR DESCRIPTION
## Summary

`sonar.python.xunit.reportPath` accepts a single wildcard expression, not a comma-separated list of paths. The previous fix incorrectly built a CSV list from `ls`. This changes it to pass `\${BUILD_DIR}/xunit-*.xml` directly whenever at least one matching file exists.

🤖 Generated with [Claude Code](https://claude.com/claude-code)